### PR TITLE
feat: add stop button to cancel in-progress generations

### DIFF
--- a/api/routers/generation.py
+++ b/api/routers/generation.py
@@ -13,6 +13,7 @@ from schemas.generation import JobStatus
 router = APIRouter(tags=["generation"])
 
 _jobs: Dict[str, JobStatus] = {}
+_cancel_events: Dict[str, threading.Event] = {}
 
 
 @router.post("/from-image")
@@ -71,6 +72,7 @@ async def generate_from_image(
 
     job = JobStatus(job_id=job_id, status="pending", progress=0)
     _jobs[job_id] = job
+    _cancel_events[job_id] = threading.Event()
 
     background_tasks.add_task(_run_generation, job_id, image_bytes, params, collection)
 
@@ -86,17 +88,46 @@ async def job_status(job_id: str):
     return job
 
 
+@router.post("/cancel/{job_id}")
+async def cancel_job(job_id: str):
+    job = _jobs.get(job_id)
+    if not job:
+        raise HTTPException(404, f"Job {job_id} not found")
+    if job.status not in ("pending", "running"):
+        return {"message": "Job already finished", "status": job.status}
+
+    evt = _cancel_events.get(job_id)
+    if evt:
+        evt.set()
+    job.status = "cancelled"
+    job.step = "Cancelled by user"
+    print(f"[Generation] Job {job_id} cancelled by user")
+    return {"message": "Job cancelled"}
+
+
+class CancelledError(Exception):
+    pass
+
+
 async def _run_generation(job_id: str, image_bytes: bytes, params: dict, collection: str = "Default") -> None:
     job = _jobs[job_id]
     job.status = "running"
+    cancel_evt = _cancel_events.get(job_id)
+
+    def check_cancelled() -> None:
+        if cancel_evt and cancel_evt.is_set():
+            raise CancelledError("Generation cancelled by user")
 
     def progress_cb(pct: int, step: str = "") -> None:
+        check_cancelled()
         job.progress = pct
         if step:
             job.step = step
 
     try:
         loop = asyncio.get_running_loop()
+
+        check_cancelled()
 
         # Check if the model needs to be loaded BEFORE calling get_active(),
         # because get_active() loads the model in a blocking manner.
@@ -118,6 +149,8 @@ async def _run_generation(job_id: str, image_bytes: bytes, params: dict, collect
         else:
             gen = await loop.run_in_executor(None, generator_registry.get_active)
 
+        check_cancelled()
+
         # Direct output to the collection subfolder
         coll_dir = WORKSPACE_DIR / collection
         coll_dir.mkdir(parents=True, exist_ok=True)
@@ -127,12 +160,31 @@ async def _run_generation(job_id: str, image_bytes: bytes, params: dict, collect
             None,
             lambda: gen.generate(image_bytes, params, progress_cb),
         )
-        job.status     = "done"
-        job.progress   = 100
-        job.output_url = f"/workspace/{collection}/{output_path.name}"
+
+        # Final check: don't mark done if cancelled while generating
+        if cancel_evt and cancel_evt.is_set():
+            job.status = "cancelled"
+            job.step = "Cancelled by user"
+        else:
+            job.status     = "done"
+            job.progress   = 100
+            job.output_url = f"/workspace/{collection}/{output_path.name}"
+
+    except CancelledError:
+        job.status = "cancelled"
+        job.step = "Cancelled by user"
+        print(f"[Generation] Job {job_id} cancelled during execution")
 
     except Exception as exc:
-        tb = traceback.format_exc()
-        print(f"[Generation ERROR] {exc}\n{tb}")
-        job.status = "error"
-        job.error  = tb.strip()
+        # Don't overwrite cancel status with error from cancel propagation
+        if cancel_evt and cancel_evt.is_set():
+            job.status = "cancelled"
+            job.step = "Cancelled by user"
+        else:
+            tb = traceback.format_exc()
+            print(f"[Generation ERROR] {exc}\n{tb}")
+            job.status = "error"
+            job.error  = tb.strip()
+
+    finally:
+        _cancel_events.pop(job_id, None)

--- a/api/schemas/generation.py
+++ b/api/schemas/generation.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 class JobStatus(BaseModel):
     job_id: str
-    status: Literal["pending", "running", "done", "error"]
+    status: Literal["pending", "running", "done", "error", "cancelled"]
     progress: int = 0              # 0–100
     step: Optional[str] = None    # Human-readable current step
     output_url: Optional[str] = None

--- a/src/areas/generate/GeneratePage.tsx
+++ b/src/areas/generate/GeneratePage.tsx
@@ -8,7 +8,7 @@ import Viewer3D from './components/Viewer3D'
 
 export default function GeneratePage(): JSX.Element {
   const selectedImagePath = useAppStore((s) => s.selectedImagePath)
-  const { currentJob, startGeneration } = useGeneration()
+  const { currentJob, startGeneration, stopGeneration } = useGeneration()
   const isGenerating = currentJob?.status === 'uploading' || currentJob?.status === 'generating'
 
   return (
@@ -22,13 +22,22 @@ export default function GeneratePage(): JSX.Element {
 
         {/* Sticky bottom: Generate button */}
         <div className="p-4 border-t border-zinc-800">
-          <button
-            onClick={() => selectedImagePath && startGeneration(selectedImagePath)}
-            disabled={!selectedImagePath || isGenerating}
-            className="w-full py-2.5 rounded-lg text-sm font-semibold bg-accent hover:bg-accent-dark disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
-          >
-            {isGenerating ? 'Generating…' : 'Generate 3D Model'}
-          </button>
+          {isGenerating ? (
+            <button
+              onClick={stopGeneration}
+              className="w-full py-2.5 rounded-lg text-sm font-semibold bg-red-600 hover:bg-red-700 text-white transition-colors"
+            >
+              Stop Generation
+            </button>
+          ) : (
+            <button
+              onClick={() => selectedImagePath && startGeneration(selectedImagePath)}
+              disabled={!selectedImagePath}
+              className="w-full py-2.5 rounded-lg text-sm font-semibold bg-accent hover:bg-accent-dark disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
+            >
+              Generate 3D Model
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/shared/hooks/useApi.ts
+++ b/src/shared/hooks/useApi.ts
@@ -38,7 +38,7 @@ export function useApi() {
   }
 
   async function pollJobStatus(jobId: string): Promise<{
-    status: 'pending' | 'running' | 'done' | 'error'
+    status: 'pending' | 'running' | 'done' | 'error' | 'cancelled'
     progress: number
     step?: string
     outputUrl?: string
@@ -46,6 +46,10 @@ export function useApi() {
   }> {
     const { data } = await client.get(`/generate/status/${jobId}`)
     return { ...data, outputUrl: data.output_url }
+  }
+
+  async function cancelJob(jobId: string): Promise<void> {
+    await client.post(`/generate/cancel/${jobId}`)
   }
 
   async function getModelStatus(): Promise<{
@@ -95,5 +99,5 @@ export function useApi() {
     return { url: data.url, faceCount: data.face_count }
   }
 
-  return { generateFromImage, pollJobStatus, getModelStatus, downloadModel, optimizeMesh }
+  return { generateFromImage, pollJobStatus, cancelJob, getModelStatus, downloadModel, optimizeMesh }
 }

--- a/src/shared/hooks/useGeneration.ts
+++ b/src/shared/hooks/useGeneration.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useAppStore } from '@shared/stores/appStore'
 import { useCollectionsStore } from '@shared/stores/collectionsStore'
 import { useApi } from './useApi'
@@ -7,10 +7,14 @@ export function useGeneration() {
   const { currentJob, setCurrentJob, updateCurrentJob, generationOptions, selectedImageData } = useAppStore()
   const addToWorkspace = useCollectionsStore((s) => s.addToWorkspace)
   const activeCollectionId = useCollectionsStore((s) => s.activeCollectionId)
-  const { generateFromImage, pollJobStatus } = useApi()
+  const { generateFromImage, pollJobStatus, cancelJob } = useApi()
+  const cancelledRef = useRef(false)
+  const activeJobIdRef = useRef<string | null>(null)
 
   const startGeneration = useCallback(
     async (imagePath: string) => {
+      cancelledRef.current = false
+
       const job = {
         id: crypto.randomUUID(),
         imageFile: imagePath,
@@ -24,16 +28,21 @@ export function useGeneration() {
 
       try {
         const { jobId } = await generateFromImage(imagePath, generationOptions, activeCollectionId, selectedImageData ?? undefined)
+        activeJobIdRef.current = jobId
+
+        if (cancelledRef.current) return
 
         updateCurrentJob({ status: 'generating', progress: 0 })
 
         // Poll until done
         await pollUntilDone(jobId)
       } catch (err) {
-        updateCurrentJob({
-          status: 'error',
-          error: err instanceof Error ? err.message : String(err)
-        })
+        if (!cancelledRef.current) {
+          updateCurrentJob({
+            status: 'error',
+            error: err instanceof Error ? err.message : String(err)
+          })
+        }
       }
     },
     [generateFromImage, pollJobStatus, setCurrentJob, updateCurrentJob, addToWorkspace, activeCollectionId]
@@ -41,8 +50,18 @@ export function useGeneration() {
 
   const pollUntilDone = async (jobId: string) => {
     while (true) {
+      if (cancelledRef.current) break
+
       await new Promise((r) => setTimeout(r, 1000))
+
+      if (cancelledRef.current) break
+
       const result = await pollJobStatus(jobId)
+
+      if (result.status === 'cancelled') {
+        updateCurrentJob({ status: 'error', error: 'Generation cancelled' })
+        break
+      }
 
       if (result.status === 'done') {
         updateCurrentJob({ status: 'done', progress: 100, outputUrl: result.outputUrl, originalOutputUrl: result.outputUrl })
@@ -63,7 +82,21 @@ export function useGeneration() {
     }
   }
 
+  const stopGeneration = useCallback(async () => {
+    cancelledRef.current = true
+    const jobId = activeJobIdRef.current
+    if (jobId) {
+      try {
+        await cancelJob(jobId)
+      } catch {
+        // Backend may have already finished
+      }
+    }
+    activeJobIdRef.current = null
+    setCurrentJob(null)
+  }, [cancelJob, setCurrentJob])
+
   const reset = useCallback(() => setCurrentJob(null), [setCurrentJob])
 
-  return { currentJob, startGeneration, reset }
+  return { currentJob, startGeneration, stopGeneration, reset }
 }


### PR DESCRIPTION
Adds a cancel/stop mechanism so users can abort a generation without waiting for it to finish or restarting the app.

Backend:
- POST /cancel/{job_id} endpoint sets a threading.Event
- Generation checks the cancel event at each progress callback and between major steps (model load, inference, mesh export)
- JobStatus now supports "cancelled" status
- Cancel events are cleaned up in a finally block

Frontend:
- Green "Generate" button becomes a red "Stop Generation" button while a job is running
- stopGeneration() sets a ref flag to break the polling loop immediately, then calls the cancel endpoint
- Polling loop checks for "cancelled" status from backend

Note: cancellation is cooperative -- it can't interrupt a PyTorch forward pass mid-tensor, but catches between pipeline steps via the progress callback. The UI resets immediately on click.