### PR TITLE
fix(extensions): accept 'ready' response as valid reply to load action

### DIFF
--- a/api/services/extension_process.py
+++ b/api/services/extension_process.py
@@ -257,7 +257,7 @@ class ExtensionProcess:
         self._send({"action": "load"})
 
         msg = self._recv(timeout=None)  # model load can be arbitrarily slow
-        if msg.get("type") == "loaded":
+        if msg.get('type') in ['loaded', 'ready']:
             self._loaded = True
         elif msg.get("type") == "error":
             raise RuntimeError(msg.get("traceback") or msg.get("message"))


### PR DESCRIPTION
Some extensions (e.g. triposg) respond to the load action with a 'ready' message (including params_schema) rather than 'loaded'. The load() method previously only accepted 'loaded', causing a RuntimeError even though the extension had initialised successfully.

Accepting both 'ready' and 'loaded' as valid load responses fixes the crash. The params_schema sent with a 'ready' reply is already captured by _start(); handling it here is a no-op but keeps the contract clear.

Reproducer:
  RuntimeError: [triposg/generate] Unexpected response to load:
  {'type': 'ready', 'params_schema': [...]}