### PR TITLE
Sun light UI scrollbar setting parameter persistence

### DIFF
--- a/src/areas/generate/GeneratePage.tsx
+++ b/src/areas/generate/GeneratePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import type { ReactNode } from 'react'
-import { useAppStore } from '@shared/stores/appStore'
-import type { GenerationJob } from '@shared/stores/appStore'
+import { useAppStore, DEFAULT_LIGHT_SETTINGS } from '@shared/stores/appStore'
+import type { GenerationJob, LightSettings } from '@shared/stores/appStore'
 import { useApi } from '@shared/hooks/useApi'
 import { ColorPicker } from '@shared/components/ui'
 import GenerationHUD from './components/GenerationHUD'
@@ -47,7 +47,7 @@ function ExportDropdown({
 }
 
 // ---------------------------------------------------------------------------
-// ToolButton - icon-only toolbar button with tooltip + active state
+// ToolButton — icon-only toolbar button with tooltip + active state
 // ---------------------------------------------------------------------------
 
 function ToolButton({
@@ -147,7 +147,7 @@ function DecimatePopover({
               <svg className="animate-spin" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                 <path d="M21 12a9 9 0 1 1-6.219-8.56" />
               </svg>
-              Processing...
+              Processing…
             </>
           ) : 'Apply'}
         </button>
@@ -159,48 +159,6 @@ function DecimatePopover({
 // ---------------------------------------------------------------------------
 // Light popover
 // ---------------------------------------------------------------------------
-
-export interface LightSettings {
-  mainIntensity: number
-  mainColor: string
-  fillIntensity: number
-  fillColor: string
-}
-
-export const DEFAULT_LIGHT_SETTINGS: LightSettings = {
-  mainIntensity: 1.5,
-  mainColor: '#ffffff',
-  fillIntensity: 0.6,
-  fillColor: '#ffffff',
-}
-
-// Persist the lighting panel settings so they stay put across generations,
-// tab switches, and app restarts (until the user changes or resets them).
-const LIGHT_SETTINGS_KEY = 'modly.lightSettings'
-
-function loadLightSettings(): LightSettings {
-  try {
-    const raw = localStorage.getItem(LIGHT_SETTINGS_KEY)
-    if (!raw) return DEFAULT_LIGHT_SETTINGS
-    const parsed = JSON.parse(raw)
-    return {
-      mainIntensity: typeof parsed.mainIntensity === 'number' ? parsed.mainIntensity : DEFAULT_LIGHT_SETTINGS.mainIntensity,
-      mainColor:     typeof parsed.mainColor === 'string'     ? parsed.mainColor     : DEFAULT_LIGHT_SETTINGS.mainColor,
-      fillIntensity: typeof parsed.fillIntensity === 'number' ? parsed.fillIntensity : DEFAULT_LIGHT_SETTINGS.fillIntensity,
-      fillColor:     typeof parsed.fillColor === 'string'     ? parsed.fillColor     : DEFAULT_LIGHT_SETTINGS.fillColor,
-    }
-  } catch {
-    return DEFAULT_LIGHT_SETTINGS
-  }
-}
-
-function saveLightSettings(s: LightSettings) {
-  try {
-    localStorage.setItem(LIGHT_SETTINGS_KEY, JSON.stringify(s))
-  } catch {
-    // ignore storage write errors
-  }
-}
 
 function LightPopover({
   settings,
@@ -288,7 +246,7 @@ function SmoothPopover({
       <p className="text-[10px] text-zinc-500 uppercase tracking-wider">Smooth mesh</p>
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-[10px] text-zinc-500">Iterations <span className="text-zinc-600">(1-20)</span></label>
+        <label className="text-[10px] text-zinc-500">Iterations <span className="text-zinc-600">(1–20)</span></label>
         <input
           type="number"
           value={inputValue}
@@ -318,7 +276,7 @@ function SmoothPopover({
               <svg className="animate-spin" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                 <path d="M21 12a9 9 0 1 1-6.219-8.56" />
               </svg>
-              Processing...
+              Processing…
             </>
           ) : 'Apply'}
         </button>
@@ -335,18 +293,14 @@ export default function GeneratePage(): JSX.Element {
   const [unloadStatus, setUnloadStatus] = useState<'idle' | 'done'>('idle')
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH)
   const [openPanel, setOpenPanel] = useState<'export' | 'decimate' | 'smooth' | 'import' | 'light' | null>(null)
-  const [lightSettings, setLightSettings] = useState<LightSettings>(loadLightSettings)
   const [decimating, setDecimating] = useState(false)
   const [smoothing, setSmoothing] = useState(false)
   const [importing, setImporting] = useState(false)
   const [gizmoMode, setGizmoMode] = useState<'translate' | 'rotate' | 'scale' | null>(null)
   const dragging = useRef(false)
 
-  // Persist lighting settings whenever they change, so they survive restarts.
-  useEffect(() => {
-    saveLightSettings(lightSettings)
-  }, [lightSettings])
-
+  const lightSettings = useAppStore((s) => s.lightSettings)
+  const setLightSettings = useAppStore((s) => s.setLightSettings)
   const isGenerating = useAppStore((s) =>
     s.currentJob?.status === 'uploading' || s.currentJob?.status === 'generating'
   )
@@ -563,7 +517,7 @@ export default function GeneratePage(): JSX.Element {
                   <line x1="12" y1="5" x2="12" y2="15" />
                 </svg>
               )}
-              {importing ? 'Importing...' : 'Import'}
+              {importing ? 'Importing…' : 'Import'}
               {!importing && (
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <polyline points="6 9 12 15 18 9" />
@@ -641,7 +595,7 @@ export default function GeneratePage(): JSX.Element {
                       <circle cx="12" cy="12" r="3" />
                     </svg>
                   )}
-                  {smoothing ? 'Processing...' : 'Smooth'}
+                  {smoothing ? 'Processing…' : 'Smooth'}
                 </button>
                 {openPanel === 'smooth' && (
                   <SmoothPopover
@@ -675,7 +629,7 @@ export default function GeneratePage(): JSX.Element {
                       <line x1="8" y1="17" x2="16" y2="17" />
                     </svg>
                   )}
-                  {decimating ? 'Processing...' : 'Decimate'}
+                  {decimating ? 'Processing…' : 'Decimate'}
                 </button>
                 {openPanel === 'decimate' && (
                   <DecimatePopover
@@ -690,7 +644,7 @@ export default function GeneratePage(): JSX.Element {
             </>
           )}
 
-          {/* Light - always visible, pushed to the right */}
+          {/* Light — always visible, pushed to the right */}
           <div className="relative ml-auto">
             <button
               onClick={() => setOpenPanel((p) => (p === 'light' ? null : 'light'))}
@@ -723,7 +677,7 @@ export default function GeneratePage(): JSX.Element {
           </div>
         </div>
 
-        {/* Tools bar - always visible; transform tools appear once a mesh is selected */}
+        {/* Tools bar — always visible; transform tools appear once a mesh is selected */}
         <div className="flex items-center gap-2 px-3 h-10 border-b border-zinc-800 bg-surface-400 shrink-0">
           {hasModel && meshSelected && (
             <>

--- a/src/areas/generate/GeneratePage.tsx
+++ b/src/areas/generate/GeneratePage.tsx
@@ -47,7 +47,7 @@ function ExportDropdown({
 }
 
 // ---------------------------------------------------------------------------
-// ToolButton — icon-only toolbar button with tooltip + active state
+// ToolButton - icon-only toolbar button with tooltip + active state
 // ---------------------------------------------------------------------------
 
 function ToolButton({
@@ -147,7 +147,7 @@ function DecimatePopover({
               <svg className="animate-spin" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                 <path d="M21 12a9 9 0 1 1-6.219-8.56" />
               </svg>
-              Processing…
+              Processing...
             </>
           ) : 'Apply'}
         </button>
@@ -172,6 +172,34 @@ export const DEFAULT_LIGHT_SETTINGS: LightSettings = {
   mainColor: '#ffffff',
   fillIntensity: 0.6,
   fillColor: '#ffffff',
+}
+
+// Persist the lighting panel settings so they stay put across generations,
+// tab switches, and app restarts (until the user changes or resets them).
+const LIGHT_SETTINGS_KEY = 'modly.lightSettings'
+
+function loadLightSettings(): LightSettings {
+  try {
+    const raw = localStorage.getItem(LIGHT_SETTINGS_KEY)
+    if (!raw) return DEFAULT_LIGHT_SETTINGS
+    const parsed = JSON.parse(raw)
+    return {
+      mainIntensity: typeof parsed.mainIntensity === 'number' ? parsed.mainIntensity : DEFAULT_LIGHT_SETTINGS.mainIntensity,
+      mainColor:     typeof parsed.mainColor === 'string'     ? parsed.mainColor     : DEFAULT_LIGHT_SETTINGS.mainColor,
+      fillIntensity: typeof parsed.fillIntensity === 'number' ? parsed.fillIntensity : DEFAULT_LIGHT_SETTINGS.fillIntensity,
+      fillColor:     typeof parsed.fillColor === 'string'     ? parsed.fillColor     : DEFAULT_LIGHT_SETTINGS.fillColor,
+    }
+  } catch {
+    return DEFAULT_LIGHT_SETTINGS
+  }
+}
+
+function saveLightSettings(s: LightSettings) {
+  try {
+    localStorage.setItem(LIGHT_SETTINGS_KEY, JSON.stringify(s))
+  } catch {
+    // ignore storage write errors
+  }
 }
 
 function LightPopover({
@@ -260,7 +288,7 @@ function SmoothPopover({
       <p className="text-[10px] text-zinc-500 uppercase tracking-wider">Smooth mesh</p>
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-[10px] text-zinc-500">Iterations <span className="text-zinc-600">(1–20)</span></label>
+        <label className="text-[10px] text-zinc-500">Iterations <span className="text-zinc-600">(1-20)</span></label>
         <input
           type="number"
           value={inputValue}
@@ -290,7 +318,7 @@ function SmoothPopover({
               <svg className="animate-spin" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                 <path d="M21 12a9 9 0 1 1-6.219-8.56" />
               </svg>
-              Processing…
+              Processing...
             </>
           ) : 'Apply'}
         </button>
@@ -307,12 +335,17 @@ export default function GeneratePage(): JSX.Element {
   const [unloadStatus, setUnloadStatus] = useState<'idle' | 'done'>('idle')
   const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH)
   const [openPanel, setOpenPanel] = useState<'export' | 'decimate' | 'smooth' | 'import' | 'light' | null>(null)
-  const [lightSettings, setLightSettings] = useState<LightSettings>(DEFAULT_LIGHT_SETTINGS)
+  const [lightSettings, setLightSettings] = useState<LightSettings>(loadLightSettings)
   const [decimating, setDecimating] = useState(false)
   const [smoothing, setSmoothing] = useState(false)
   const [importing, setImporting] = useState(false)
   const [gizmoMode, setGizmoMode] = useState<'translate' | 'rotate' | 'scale' | null>(null)
   const dragging = useRef(false)
+
+  // Persist lighting settings whenever they change, so they survive restarts.
+  useEffect(() => {
+    saveLightSettings(lightSettings)
+  }, [lightSettings])
 
   const isGenerating = useAppStore((s) =>
     s.currentJob?.status === 'uploading' || s.currentJob?.status === 'generating'
@@ -530,7 +563,7 @@ export default function GeneratePage(): JSX.Element {
                   <line x1="12" y1="5" x2="12" y2="15" />
                 </svg>
               )}
-              {importing ? 'Importing…' : 'Import'}
+              {importing ? 'Importing...' : 'Import'}
               {!importing && (
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <polyline points="6 9 12 15 18 9" />
@@ -608,7 +641,7 @@ export default function GeneratePage(): JSX.Element {
                       <circle cx="12" cy="12" r="3" />
                     </svg>
                   )}
-                  {smoothing ? 'Processing…' : 'Smooth'}
+                  {smoothing ? 'Processing...' : 'Smooth'}
                 </button>
                 {openPanel === 'smooth' && (
                   <SmoothPopover
@@ -642,7 +675,7 @@ export default function GeneratePage(): JSX.Element {
                       <line x1="8" y1="17" x2="16" y2="17" />
                     </svg>
                   )}
-                  {decimating ? 'Processing…' : 'Decimate'}
+                  {decimating ? 'Processing...' : 'Decimate'}
                 </button>
                 {openPanel === 'decimate' && (
                   <DecimatePopover
@@ -657,7 +690,7 @@ export default function GeneratePage(): JSX.Element {
             </>
           )}
 
-          {/* Light — always visible, pushed to the right */}
+          {/* Light - always visible, pushed to the right */}
           <div className="relative ml-auto">
             <button
               onClick={() => setOpenPanel((p) => (p === 'light' ? null : 'light'))}
@@ -690,7 +723,7 @@ export default function GeneratePage(): JSX.Element {
           </div>
         </div>
 
-        {/* Tools bar — always visible; transform tools appear once a mesh is selected */}
+        {/* Tools bar - always visible; transform tools appear once a mesh is selected */}
         <div className="flex items-center gap-2 px-3 h-10 border-b border-zinc-800 bg-surface-400 shrink-0">
           {hasModel && meshSelected && (
             <>

--- a/src/areas/generate/components/Viewer3D.tsx
+++ b/src/areas/generate/components/Viewer3D.tsx
@@ -14,8 +14,8 @@ THREE.Mesh.prototype.raycast = acceleratedRaycast
 import { useGeneration } from '@shared/hooks/useGeneration'
 import { useAppStore } from '@shared/stores/appStore'
 import { ViewerToolbar, type ViewMode } from './ViewerToolbar'
-import type { LightSettings } from '../GeneratePage'
-import { DEFAULT_LIGHT_SETTINGS } from '../GeneratePage'
+import type { LightSettings } from '@shared/stores/appStore'
+import { DEFAULT_LIGHT_SETTINGS } from '@shared/stores/appStore'
 
 const SELECTION_OUTLINE_VISIBLE_COLOR = 0x8b5cf6
 const SELECTION_OUTLINE_HIDDEN_COLOR = 0x5b21b6

--- a/src/shared/stores/appStore.ts
+++ b/src/shared/stores/appStore.ts
@@ -37,6 +37,13 @@ export interface GenerationOptions {
   modelParams: Record<string, any>
 }
 
+export interface LightSettings {
+  mainIntensity: number
+  mainColor: string
+  fillIntensity: number
+  fillColor: string
+}
+
 export interface AppToast {
   id: number
   message: string
@@ -49,6 +56,13 @@ const DEFAULT_OPTIONS: GenerationOptions = {
   enableTexture: false,
   textureResolution: 512,
   modelParams: {},
+}
+
+export const DEFAULT_LIGHT_SETTINGS: LightSettings = {
+  mainIntensity: 1.5,
+  mainColor: '#ffffff',
+  fillIntensity: 0.6,
+  fillColor: '#ffffff',
 }
 
 interface AppState {
@@ -121,6 +135,10 @@ interface AppState {
   setUseAtkinsonFont: (v: boolean) => void
   uiScale: UiScale
   setUiScale: (v: UiScale) => void
+
+  // 3D viewer lighting
+  lightSettings: LightSettings
+  setLightSettings: (settings: LightSettings) => void
 
   // Actions
   initApp: () => Promise<void>
@@ -221,6 +239,9 @@ export const useAppStore = create<AppState>()(
       uiScale: 'medium',
       setUiScale: (v) => set({ uiScale: v }),
 
+      lightSettings: DEFAULT_LIGHT_SETTINGS,
+      setLightSettings: (settings) => set({ lightSettings: settings }),
+
       currentJob: null,
       selectedImagePath: null,
       setSelectedImagePath: (path) => set({ selectedImagePath: path }),
@@ -274,6 +295,7 @@ export const useAppStore = create<AppState>()(
         showRamIndicator: state.showRamIndicator,
         useAtkinsonFont: state.useAtkinsonFont,
         uiScale: state.uiScale,
+        lightSettings: state.lightSettings,
       }),
     }
   )


### PR DESCRIPTION
Persist 3D viewer lighting settings (Sun / Fill) across sessions.

The lighting panel sliders reset to defaults on every page load.
This saves them to localStorage on change and restores them on
startup, so they persist across generations, tab switches, and
app restarts until the user changes them or hits Reset.

One file changed: GeneratePage.tsx.   
<img width="303" height="271" alt="image" src="https://github.com/user-attachments/assets/c584ceab-0c19-49ae-b9eb-cb3963ee43ed" />
