### PR TITLE
fix(workflows): remove variant selector from extension node

### DIFF
--- a/src/areas/workflows/nodes/ExtensionNode.tsx
+++ b/src/areas/workflows/nodes/ExtensionNode.tsx
@@ -129,14 +129,6 @@ export default function ExtensionNode({ id, data, selected }: { id: string; data
   const { modelExtensions, processExtensions } = useExtensionsStore()
   const allExtensions = buildAllWorkflowExtensions(modelExtensions, processExtensions)
   const ext = allExtensions.find((e) => e.id === data.extensionId)
-  const siblingVariants = ext
-    ? allExtensions.filter((e) =>
-        e.extensionId === ext.extensionId &&
-        e.type === ext.type &&
-        e.input === ext.input &&
-        e.output === ext.output,
-      )
-    : []
 
   const inputs      = ext?.inputs  // defined → multi-input mode
   const isMulti     = inputs && inputs.length > 1
@@ -260,22 +252,6 @@ export default function ExtensionNode({ id, data, selected }: { id: string; data
     >
       {hasParams && (
         <div className="px-3 pb-3 pt-2.5 flex flex-col gap-2">
-          {siblingVariants.length > 1 && (
-            <div className="flex items-center gap-2">
-              <label className="text-[10px] text-zinc-500 w-20 shrink-0 truncate">Variant</label>
-              <div className="flex-1">
-                <select
-                  value={ext?.id ?? data.extensionId ?? ''}
-                  onChange={(e) => updateNodeData(id, { extensionId: e.target.value })}
-                  className={inputCls}
-                >
-                  {siblingVariants.map((variant) => (
-                    <option key={variant.id} value={variant.id}>{variant.name}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-          )}
           {ext!.params.filter(isVisible).map((param) => {
             const val = (data.params[param.id] ?? param.default) as number | string
             return (


### PR DESCRIPTION
## Summary
Removes the **Variant** `<select>` from the workflow `ExtensionNode`.

The selector (added in the Apple Silicon PR, `3f20868`) let users switch a node between sibling extension variants sharing the same `extensionId`/`type`/`input`/`output`. Variant selection is already handled elsewhere in the app, so the in-node dropdown was redundant. This also drops the now-unused `siblingVariants` computation.

## Changes
- `src/areas/workflows/nodes/ExtensionNode.tsx`: remove the `Variant` select block and the `siblingVariants` filter (-24 lines).

## Verification
- `npm run build` passes (1004 modules transformed, no type/import errors).
- Change is delete-only; `updateNodeData` remains used elsewhere in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)