### PR TITLE
Fix/text input node output to expand to model nodes

### DIFF
--- a/src/areas/workflows/workflowRunStore.ts
+++ b/src/areas/workflows/workflowRunStore.ts
@@ -163,20 +163,20 @@ async function executeExtensionNode(
       if (src.outputType === 'mesh')        nodeInputMeshPath = src.filePath
       else if (src.outputType === 'image')  nodeInputPath     = src.filePath
       else if (src.filePath !== undefined)  nodeInputPath     = src.filePath
-      if (src.text !== undefined)           nodeInputText     = src.text
+      if (src.text !== undefined && src.text.trim().length > 0) nodeInputText = src.text
     }
   } else {
     for (const edge of incomingEdges) {
       const src = resolveSource(edge.source)
       if (src?.filePath !== undefined) nodeInputPath = src.filePath
-      if (src?.text     !== undefined) nodeInputText = src.text
+      if (src?.text !== undefined && src.text.trim().length > 0) nodeInputText = src.text
     }
   }
 
   const isModelNode = ext?.type === 'model'
 
   if (isModelNode) {
-    const isTextInput = ext?.input === 'text' || (ext?.inputs && ext.inputs.every((i) => i === 'text'))
+    const isTextInput = ext?.inputs ? ext.inputs.every((i) => i === 'text') : ext?.input === 'text'
     const activeImagePath = isTextInput ? undefined : (nodeInputPath ?? selectedImagePath)
     if (!isTextInput && !selectedImageData && (!activeImagePath || activeImagePath.trim().length === 0)) {
       throw new Error('No input image selected for model node')

--- a/src/areas/workflows/workflowRunStore.ts
+++ b/src/areas/workflows/workflowRunStore.ts
@@ -176,16 +176,26 @@ async function executeExtensionNode(
   const isModelNode = ext?.type === 'model'
 
   if (isModelNode) {
-    const activeImagePath = nodeInputPath ?? selectedImagePath
-    if (!selectedImageData && (!activeImagePath || activeImagePath.trim().length === 0)) {
+    const isTextInput = ext?.input === 'text' || (ext?.inputs && ext.inputs.every((i) => i === 'text'))
+    const activeImagePath = isTextInput ? undefined : (nodeInputPath ?? selectedImagePath)
+    if (!isTextInput && !selectedImageData && (!activeImagePath || activeImagePath.trim().length === 0)) {
       throw new Error('No input image selected for model node')
     }
-    const base64 = selectedImageData && nodeInputPath === undefined
-      ? selectedImageData
-      : await window.electron.fs.readFileBase64(activeImagePath as string)
-    const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
-    const blob  = new Blob([bytes], { type: 'image/png' })
-    const fname = activeImagePath?.split(/[\\/]/).pop() ?? 'image.png'
+
+    let blob: Blob
+    let fname: string
+    if (isTextInput || (!activeImagePath && selectedImageData)) {
+      const base64 = selectedImageData && nodeInputPath === undefined
+        ? selectedImageData
+        : 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' // 1x1 transparent PNG
+      fname = 'placeholder.png'
+      blob = new Blob([Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))], { type: 'image/png' })
+    } else {
+      const base64 = await window.electron.fs.readFileBase64(activeImagePath as string)
+      const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
+      blob = new Blob([bytes], { type: 'image/png' })
+      fname = activeImagePath?.split(/[\\/]/).pop() ?? 'image.png'
+    }
 
     const extraParams: Record<string, unknown> = {}
     if (nodeInputMeshPath) {
@@ -193,6 +203,10 @@ async function executeExtensionNode(
       extraParams.mesh_path = norm.startsWith(workspaceDir)
         ? norm.slice(workspaceDir.length).replace(/^\//, '')
         : norm
+    }
+    if (nodeInputText !== undefined && nodeInputText.trim().length > 0) {
+      extraParams.prompt = nodeInputText
+      extraParams.text   = nodeInputText
     }
 
     const schemaDefaults = Object.fromEntries(


### PR DESCRIPTION
The Text node has been in the node palette for a while and stores text output fine, but model-type extensions (like my HunyuanDiT t2i) never actually received that text — the runner only sent images. If you wired a Text node into a model it would just throw "No input image selected" and never run.

This PR:

Checks the extension's declared input type — if it's "text", skip the image requirement and send a minimal placeholder instead (the extension ignores it anyway).
Passes the text from any connected source into params["prompt"] so the API gets the prompt.
The multi-input handle routing (input-0, input-1, etc.) that was already in place now also captures nodeInputText from connected sources, so this works for both single and multi-input model nodes.
