### PR TITLE
feat/add single-image preview node, fix text-only detection for multi-input models

### DIFF
--- a/src/areas/workflows/WorkflowsPage.tsx
+++ b/src/areas/workflows/WorkflowsPage.tsx
@@ -29,6 +29,7 @@ import TextNode         from './nodes/TextNode'
 import AddToSceneNode   from './nodes/AddToSceneNode'
 import Load3DMeshNode   from './nodes/Load3DMeshNode'
 import PreviewImageNode from './nodes/PreviewImageNode'
+import ImagePreviewNode from './nodes/ImagePreviewNode'
 import WaitNode         from './nodes/WaitNode'
 import WorkflowEdge     from './nodes/WorkflowEdge'
 
@@ -36,7 +37,7 @@ import WorkflowEdge     from './nodes/WorkflowEdge'
 
 const DRAG_KEY      = 'modly/extension-id'
 const DRAG_NODE_KEY = 'modly/node-type'
-const NODE_TYPES = { extensionNode: ExtensionNode, imageNode: ImageNode, textNode: TextNode, outputNode: AddToSceneNode, meshNode: Load3DMeshNode, previewNode: PreviewImageNode, waitNode: WaitNode }
+const NODE_TYPES = { extensionNode: ExtensionNode, imageNode: ImageNode, textNode: TextNode, outputNode: AddToSceneNode, meshNode: Load3DMeshNode, previewNode: PreviewImageNode, imagePreviewNode: ImagePreviewNode, waitNode: WaitNode }
 const EDGE_TYPES = { workflowEdge: WorkflowEdge }
 
 const DEFAULT_EDGE_OPTS = { type: 'workflowEdge' }
@@ -158,6 +159,7 @@ const PANEL_BUILTIN_NODES = [
   { type: 'meshNode',    label: 'Load 3D Mesh',   color: '#a78bfa', icon: <><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></> },
   { type: 'outputNode',  label: 'Add to Scene',   color: '#a78bfa', icon: <><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></> },
   { type: 'previewNode', label: 'Preview Views',  color: '#38bdf8', icon: <><rect x="3" y="3" width="8" height="8" rx="1"/><rect x="13" y="3" width="8" height="8" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="13" y="13" width="8" height="8" rx="1"/></> },
+  { type: 'imagePreviewNode', label: 'Preview Image',  color: '#38bdf8', icon: <><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></> },
   { type: 'waitNode',    label: 'Wait',           color: '#71717a', icon: <><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></> },
 ]
 
@@ -402,6 +404,7 @@ const BUILTIN_NODES = [
   { type: 'meshNode',    label: 'Load 3D Mesh',   color: '#a78bfa', description: 'Load a 3D mesh file or use current model' },
   { type: 'outputNode',  label: 'Add to Scene',   color: '#a78bfa', description: 'Output node — adds the mesh to the 3D scene' },
   { type: 'previewNode', label: 'Preview Views',  color: '#38bdf8', description: 'Displays multi-view image outputs in a 2×3 grid' },
+  { type: 'imagePreviewNode', label: 'Preview Image',  color: '#38bdf8', description: 'Displays a single image output in the workflow' },
   { type: 'waitNode',    label: 'Wait',           color: '#71717a', description: 'Pauses the workflow until you click Continue' },
 ]
 
@@ -747,6 +750,7 @@ function getNodeOutputType(node: Node | undefined, allExts: WorkflowExtension[])
   if (node.type === 'imageNode') return 'image'
   if (node.type === 'meshNode')  return 'mesh'
   if (node.type === 'textNode')  return 'text'
+  if (node.type === 'imagePreviewNode') return 'image'
   return allExts.find((e) => e.id === (node.data as WFNodeData)?.extensionId)?.output
 }
 
@@ -758,6 +762,7 @@ function getNodeInputType(
   if (!node) return undefined
   if (node.type === 'outputNode')  return 'mesh'
   if (node.type === 'previewNode') return 'image'
+  if (node.type === 'imagePreviewNode') return 'image'
   const ext = allExts.find((e) => e.id === (node.data as WFNodeData)?.extensionId)
   if (ext?.inputs && ext.inputs.length > 1 && targetHandle) {
     const idx = parseInt(targetHandle.replace('input-', ''), 10)

--- a/src/areas/workflows/WorkflowsPage.tsx
+++ b/src/areas/workflows/WorkflowsPage.tsx
@@ -28,6 +28,7 @@ import TextNode         from './nodes/TextNode'
 import AddToSceneNode   from './nodes/AddToSceneNode'
 import Load3DMeshNode   from './nodes/Load3DMeshNode'
 import PreviewImageNode from './nodes/PreviewImageNode'
+import ImagePreviewNode from './nodes/ImagePreviewNode'
 import WaitNode         from './nodes/WaitNode'
 import WhileNode        from './nodes/WhileNode'
 import ForEachNode      from './nodes/ForEachNode'
@@ -37,7 +38,7 @@ import WorkflowEdge     from './nodes/WorkflowEdge'
 
 const DRAG_KEY      = 'modly/extension-id'
 const DRAG_NODE_KEY = 'modly/node-type'
-const NODE_TYPES = { extensionNode: ExtensionNode, imageNode: ImageNode, textNode: TextNode, outputNode: AddToSceneNode, meshNode: Load3DMeshNode, previewNode: PreviewImageNode, waitNode: WaitNode, whileNode: WhileNode, forEachNode: ForEachNode }
+const NODE_TYPES = { extensionNode: ExtensionNode, imageNode: ImageNode, textNode: TextNode, outputNode: AddToSceneNode, meshNode: Load3DMeshNode, previewNode: PreviewImageNode, imagePreviewNode: ImagePreviewNode, waitNode: WaitNode, whileNode: WhileNode, forEachNode: ForEachNode }
 
 // Loop-container node types: resizable frames whose children form a loop body.
 // (For Each iterators are plain source nodes, not containers.)
@@ -100,6 +101,7 @@ const PANEL_BUILTIN_NODES = [
   { type: 'meshNode',    label: 'Load 3D Mesh',   color: '#a78bfa', icon: <><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></> },
   { type: 'outputNode',  label: 'Add to Scene',   color: '#a78bfa', icon: <><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></> },
   { type: 'previewNode', label: 'Preview Views',  color: '#38bdf8', icon: <><rect x="3" y="3" width="8" height="8" rx="1"/><rect x="13" y="3" width="8" height="8" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="13" y="13" width="8" height="8" rx="1"/></> },
+  { type: 'imagePreviewNode', label: 'Preview Image',  color: '#38bdf8', icon: <><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></> },
   { type: 'waitNode',    label: 'Wait',           color: '#71717a', icon: <><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></> },
   { type: 'whileNode',   label: 'While',          color: '#f59e0b', icon: <><polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><polyline points="7 23 3 19 7 15"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></> },
   { type: 'forEachNode', label: 'For Each', color: '#38bdf8', icon: <><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></> },
@@ -346,6 +348,7 @@ const BUILTIN_NODES = [
   { type: 'meshNode',    label: 'Load 3D Mesh',   color: '#a78bfa', description: 'Load a 3D mesh file or use current model' },
   { type: 'outputNode',  label: 'Add to Scene',   color: '#a78bfa', description: 'Output node — adds the mesh to the 3D scene' },
   { type: 'previewNode', label: 'Preview Views',  color: '#38bdf8', description: 'Displays multi-view image outputs in a 2×3 grid' },
+  { type: 'imagePreviewNode', label: 'Preview Image',  color: '#38bdf8', description: 'Displays a single image output in the workflow' },
   { type: 'waitNode',    label: 'Wait',           color: '#71717a', description: 'Pauses the workflow until you click Continue' },
   { type: 'whileNode',   label: 'While',          color: '#f59e0b', description: 'Container: wrap nodes to loop them N times or with Continue/Retry' },
   { type: 'forEachNode', label: 'For Each', color: '#38bdf8', description: 'Iterates a folder (image / text / mesh) alphabetically, one item per run of the downstream nodes' },
@@ -701,6 +704,7 @@ function getNodeOutputType(node: Node | undefined, allExts: WorkflowExtension[])
   if (node.type === 'imageNode') return 'image'
   if (node.type === 'meshNode')  return 'mesh'
   if (node.type === 'textNode')  return 'text'
+  if (node.type === 'imagePreviewNode') return 'image'
   return allExts.find((e) => e.id === (node.data as WFNodeData)?.extensionId)?.output
 }
 
@@ -712,6 +716,7 @@ function getNodeInputType(
   if (!node) return undefined
   if (node.type === 'outputNode')  return 'mesh'
   if (node.type === 'previewNode') return 'image'
+  if (node.type === 'imagePreviewNode') return 'image'
   const ext = allExts.find((e) => e.id === (node.data as WFNodeData)?.extensionId)
   if (ext?.inputs && ext.inputs.length > 1 && targetHandle) {
     const idx = parseInt(targetHandle.replace('input-', ''), 10)

--- a/src/areas/workflows/nodeBehaviors.ts
+++ b/src/areas/workflows/nodeBehaviors.ts
@@ -23,9 +23,10 @@ export interface NodeBehavior {
 }
 
 const BEHAVIORS: Record<string, NodeBehavior> = {
-  waitNode:      { passthrough: true, branchStarter: true },
-  outputNode:    { sceneOutput: true, branchConsumer: true },
-  extensionNode: { branchConsumer: true },
+  waitNode:         { passthrough: true, branchStarter: true },
+  outputNode:       { sceneOutput: true, branchConsumer: true },
+  extensionNode:    { branchConsumer: true },
+  imagePreviewNode: { passthrough: true },
 }
 
 export const isPassthrough    = (type: string | undefined): boolean => !!type && !!BEHAVIORS[type]?.passthrough

--- a/src/areas/workflows/nodes/ImageNode.tsx
+++ b/src/areas/workflows/nodes/ImageNode.tsx
@@ -2,15 +2,9 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { Handle, Position, useReactFlow } from '@xyflow/react'
 import type { WFNodeData } from '@shared/types/electron.d'
 import BaseNode from './BaseNode'
+import { mimeFromPath } from './imageUtils'
 
 const OUTPUT_COLOR = '#38bdf8'
-
-function mimeFromPath(p: string): string {
-  const ext = p.split('.').pop()?.toLowerCase() ?? ''
-  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
-  if (ext === 'webp') return 'image/webp'
-  return 'image/png'
-}
 
 export default function ImageNode({ id, data, selected }: { id: string; data: WFNodeData; selected?: boolean }) {
   const { updateNodeData } = useReactFlow()

--- a/src/areas/workflows/nodes/ImagePreviewNode.tsx
+++ b/src/areas/workflows/nodes/ImagePreviewNode.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { Handle, Position, useReactFlow } from '@xyflow/react'
+import { Handle, Position, useEdges, useNodes } from '@xyflow/react'
 import { useWorkflowRunStore } from '../workflowRunStore'
 import BaseNode from './BaseNode'
 
@@ -14,7 +14,8 @@ function mimeFromPath(p: string): string {
 
 export default function ImagePreviewNode({ id, selected }: { id: string; selected?: boolean }) {
   const nodeImageOutputs = useWorkflowRunStore((s) => s.nodeImageOutputs)
-  const { getEdges }     = useReactFlow()
+  const edges            = useEdges()
+  const nodes            = useNodes()
   const ioRowRef         = useRef<HTMLDivElement>(null)
   const [handleTop, setHandleTop] = useState('50%')
   const [dataUrl, setDataUrl]     = useState<string | undefined>(undefined)
@@ -26,29 +27,38 @@ export default function ImagePreviewNode({ id, selected }: { id: string; selecte
     }
   }, [])
 
-  const incomingEdge = getEdges().find((e) => e.target === id)
-  const workspaceUrl = incomingEdge ? nodeImageOutputs[incomingEdge.source] : undefined
+  const incomingEdge  = edges.find((e) => e.target === id)
+  const sourceNode    = incomingEdge ? nodes.find((n) => n.id === incomingEdge.source) : undefined
+  const workspaceUrl  = incomingEdge ? nodeImageOutputs[incomingEdge.source] : undefined
+  const imageFilePath = sourceNode?.type === 'imageNode'
+    ? (sourceNode.data as { params?: { filePath?: string } })?.params?.filePath
+    : undefined
 
   useEffect(() => {
     let cancelled = false
-    if (!workspaceUrl) {
+    if (!workspaceUrl && !imageFilePath) {
       setDataUrl(undefined)
       return
     }
     ;(async () => {
       try {
-        const settings = await window.electron.settings.get()
-        const wsDir    = settings.workspaceDir.replace(/\\/g, '/').replace(/\/+$/, '')
-        const rel      = workspaceUrl.replace(/^\/workspace\//, '')
-        const absPath  = `${wsDir}/${rel}`
-        const base64   = await window.electron.fs.readFileBase64(absPath)
+        let absPath: string
+        if (workspaceUrl) {
+          const settings = await window.electron.settings.get()
+          const wsDir    = settings.workspaceDir.replace(/\\/g, '/').replace(/\/+$/, '')
+          const rel      = workspaceUrl.replace(/^\/workspace\//, '')
+          absPath        = `${wsDir}/${rel}`
+        } else {
+          absPath = imageFilePath!
+        }
+        const base64 = await window.electron.fs.readFileBase64(absPath)
         if (!cancelled) setDataUrl(`data:${mimeFromPath(absPath)};base64,${base64}`)
       } catch {
         if (!cancelled) setDataUrl(undefined)
       }
     })()
     return () => { cancelled = true }
-  }, [workspaceUrl])
+  }, [workspaceUrl, imageFilePath])
 
   return (
     <BaseNode

--- a/src/areas/workflows/nodes/ImagePreviewNode.tsx
+++ b/src/areas/workflows/nodes/ImagePreviewNode.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Handle, Position, useReactFlow } from '@xyflow/react'
+import { useWorkflowRunStore } from '../workflowRunStore'
+import BaseNode from './BaseNode'
+
+const IO_COLOR = '#38bdf8'
+
+function mimeFromPath(p: string): string {
+  const ext = p.split('.').pop()?.toLowerCase() ?? ''
+  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+  if (ext === 'webp') return 'image/webp'
+  return 'image/png'
+}
+
+export default function ImagePreviewNode({ id, selected }: { id: string; selected?: boolean }) {
+  const nodeImageOutputs = useWorkflowRunStore((s) => s.nodeImageOutputs)
+  const { getEdges }     = useReactFlow()
+  const ioRowRef         = useRef<HTMLDivElement>(null)
+  const [handleTop, setHandleTop] = useState('50%')
+  const [dataUrl, setDataUrl]     = useState<string | undefined>(undefined)
+
+  useLayoutEffect(() => {
+    if (ioRowRef.current) {
+      const center = ioRowRef.current.offsetTop + ioRowRef.current.offsetHeight / 2
+      setHandleTop(`${center}px`)
+    }
+  }, [])
+
+  const incomingEdge = getEdges().find((e) => e.target === id)
+  const workspaceUrl = incomingEdge ? nodeImageOutputs[incomingEdge.source] : undefined
+
+  useEffect(() => {
+    let cancelled = false
+    if (!workspaceUrl) {
+      setDataUrl(undefined)
+      return
+    }
+    ;(async () => {
+      try {
+        const settings = await window.electron.settings.get()
+        const wsDir    = settings.workspaceDir.replace(/\\/g, '/').replace(/\/+$/, '')
+        const rel      = workspaceUrl.replace(/^\/workspace\//, '')
+        const absPath  = `${wsDir}/${rel}`
+        const base64   = await window.electron.fs.readFileBase64(absPath)
+        if (!cancelled) setDataUrl(`data:${mimeFromPath(absPath)};base64,${base64}`)
+      } catch {
+        if (!cancelled) setDataUrl(undefined)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [workspaceUrl])
+
+  return (
+    <BaseNode
+      id={id}
+      selected={selected}
+      title="Preview Image"
+      minWidth={180}
+      icon={
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke={IO_COLOR} strokeWidth="2">
+          <rect x="3" y="3" width="18" height="18" rx="2"/>
+          <circle cx="8.5" cy="8.5" r="1.5"/>
+          <polyline points="21 15 16 10 5 21"/>
+        </svg>
+      }
+      subheader={
+        <div ref={ioRowRef} className="flex items-center justify-between px-3 py-2">
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium border border-sky-500/30 bg-sky-500/10 text-sky-400">image</span>
+          <span className="text-[9px] text-zinc-600">&rarr;</span>
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium border border-sky-500/30 bg-sky-500/10 text-sky-400">image</span>
+        </div>
+      }
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Left}
+            style={{ background: IO_COLOR, width: 14, height: 14, border: '2.5px solid #18181b', top: handleTop }}
+          />
+          <Handle
+            type="source"
+            position={Position.Right}
+            style={{ background: IO_COLOR, width: 14, height: 14, border: '2.5px solid #18181b', top: handleTop }}
+          />
+        </>
+      }
+    >
+      <div className="px-2 pb-2 pt-1 flex-1 min-h-0">
+        {dataUrl ? (
+          <img src={dataUrl} alt="preview" className="nodrag w-full h-full object-contain rounded" />
+        ) : (
+          <p className="py-3 text-center text-[10px] text-zinc-600 italic">
+            Connect an image and run to preview.
+          </p>
+        )}
+      </div>
+    </BaseNode>
+  )
+}

--- a/src/areas/workflows/nodes/ImagePreviewNode.tsx
+++ b/src/areas/workflows/nodes/ImagePreviewNode.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Handle, Position, useEdges, useNodes } from '@xyflow/react'
 import { useWorkflowRunStore, fromWorkspaceUrl } from '../workflowRunStore'
+import { resolveDataSource } from '../nodeBehaviors'
 import BaseNode from './BaseNode'
 import { mimeFromPath } from './imageUtils'
+import type { WFNode } from '@shared/types/electron.d'
 
 const IO_COLOR = '#38bdf8'
 
@@ -32,8 +34,12 @@ export default function ImagePreviewNode({ id, selected }: { id: string; selecte
   }, [])
 
   const incomingEdge  = edges.find((e) => e.target === id)
-  const sourceNode    = incomingEdge ? nodes.find((n) => n.id === incomingEdge.source) : undefined
-  const workspaceUrl  = incomingEdge ? nodeImageOutputs[incomingEdge.source] : undefined
+  const nodeMap       = new Map(nodes.map((n) => [n.id, n as unknown as WFNode]))
+  const realSourceId  = incomingEdge
+    ? resolveDataSource(incomingEdge.source, edges, nodeMap)
+    : undefined
+  const sourceNode    = realSourceId ? nodes.find((n) => n.id === realSourceId) : undefined
+  const workspaceUrl  = realSourceId ? nodeImageOutputs[realSourceId] : undefined
   const imageFilePath = sourceNode?.type === 'imageNode'
     ? (sourceNode.data as { params?: { filePath?: string } })?.params?.filePath
     : undefined

--- a/src/areas/workflows/nodes/ImagePreviewNode.tsx
+++ b/src/areas/workflows/nodes/ImagePreviewNode.tsx
@@ -1,17 +1,21 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Handle, Position, useEdges, useNodes } from '@xyflow/react'
-import { useWorkflowRunStore } from '../workflowRunStore'
+import { useWorkflowRunStore, fromWorkspaceUrl } from '../workflowRunStore'
 import BaseNode from './BaseNode'
+import { mimeFromPath } from './imageUtils'
 
 const IO_COLOR = '#38bdf8'
 
-function mimeFromPath(p: string): string {
-  const ext = p.split('.').pop()?.toLowerCase() ?? ''
-  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
-  if (ext === 'webp') return 'image/webp'
-  return 'image/png'
-}
-
+/**
+ * Single-image passthrough preview: an image in, the same image forwarded out
+ * unchanged. Distinct from PreviewImageNode ("Preview Views"), which is a
+ * terminal node for multi-view strip outputs (e.g. MV-Adapter) and has no
+ * output handle.
+ *
+ * Reads the source file straight off disk and renders it as a `data:` URL
+ * (rather than an API-served URL) so the preview works without depending on
+ * the backend being up or CSP allowances for a remote origin.
+ */
 export default function ImagePreviewNode({ id, selected }: { id: string; selected?: boolean }) {
   const nodeImageOutputs = useWorkflowRunStore((s) => s.nodeImageOutputs)
   const edges            = useEdges()
@@ -45,9 +49,7 @@ export default function ImagePreviewNode({ id, selected }: { id: string; selecte
         let absPath: string
         if (workspaceUrl) {
           const settings = await window.electron.settings.get()
-          const wsDir    = settings.workspaceDir.replace(/\\/g, '/').replace(/\/+$/, '')
-          const rel      = workspaceUrl.replace(/^\/workspace\//, '')
-          absPath        = `${wsDir}/${rel}`
+          absPath        = fromWorkspaceUrl(workspaceUrl, settings.workspaceDir)
         } else {
           absPath = imageFilePath!
         }

--- a/src/areas/workflows/nodes/imageUtils.ts
+++ b/src/areas/workflows/nodes/imageUtils.ts
@@ -1,0 +1,8 @@
+// Shared helpers for node components that read image files from disk.
+
+export function mimeFromPath(p: string): string {
+  const ext = p.split('.').pop()?.toLowerCase() ?? ''
+  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+  if (ext === 'webp') return 'image/webp'
+  return 'image/png'
+}

--- a/src/areas/workflows/preflight.ts
+++ b/src/areas/workflows/preflight.ts
@@ -16,6 +16,7 @@ function nodeLabel(node: WFNode, allExtensions: WorkflowExtension[]): string {
   if (node.type === 'meshNode') return 'Load 3D Mesh'
   if (node.type === 'outputNode') return 'Add to Scene'
   if (node.type === 'previewNode') return 'Preview Views'
+  if (node.type === 'imagePreviewNode') return 'Preview Image'
   if (node.type === 'extensionNode') {
     return getWorkflowExtension(node.data.extensionId ?? '', allExtensions)?.name ?? 'Extension'
   }
@@ -39,6 +40,7 @@ function getNodeOutputType(node: WFNode, allExtensions: WorkflowExtension[]): Da
   if (node.type === 'textNode') return 'text'
   if (node.type === 'meshNode' || node.type === 'outputNode') return 'mesh'
   if (node.type === 'previewNode') return 'image'
+  if (node.type === 'imagePreviewNode') return 'image'
   if (node.type === 'extensionNode') {
     return getWorkflowExtension(node.data.extensionId ?? '', allExtensions)?.output
   }

--- a/src/areas/workflows/preflight.ts
+++ b/src/areas/workflows/preflight.ts
@@ -16,6 +16,7 @@ function nodeLabel(node: WFNode, allExtensions: WorkflowExtension[]): string {
   if (node.type === 'meshNode') return 'Load 3D Mesh'
   if (node.type === 'outputNode') return 'Add to Scene'
   if (node.type === 'previewNode') return 'Preview Views'
+  if (node.type === 'imagePreviewNode') return 'Preview Image'
   if (node.type === 'forEachNode') {
     const mode = (node.data.params?.mode as string) ?? 'image'
     return mode === 'text' ? 'For Each Text' : mode === 'mesh' ? 'For Each Mesh' : 'For Each Image'
@@ -44,6 +45,7 @@ function getNodeOutputType(node: WFNode, allExtensions: WorkflowExtension[]): Da
   if (node.type === 'textNode') return 'text'
   if (node.type === 'meshNode' || node.type === 'outputNode') return 'mesh'
   if (node.type === 'previewNode') return 'image'
+  if (node.type === 'imagePreviewNode') return 'image'
   if (node.type === 'forEachNode') {
     const mode = (node.data.params?.mode as DataType | undefined) ?? 'image'
     return mode === 'text' || mode === 'mesh' ? mode : 'image'

--- a/src/areas/workflows/workflowRunStore.ts
+++ b/src/areas/workflows/workflowRunStore.ts
@@ -118,6 +118,14 @@ function toWorkspaceUrl(filePath: string, workspaceDir: string): string | undefi
   return `/workspace/${norm.slice(workspaceDir.length).replace(/^\//, '')}`
 }
 
+// Inverse of toWorkspaceUrl — used by node components that read a `/workspace/...`
+// output URL back off disk (e.g. to build a data: URL for a preview).
+export function fromWorkspaceUrl(url: string, workspaceDir: string): string {
+  const wsDir = workspaceDir.replace(/\\/g, '/').replace(/\/+$/, '')
+  const rel   = url.replace(/^\/workspace\//, '')
+  return `${wsDir}/${rel}`
+}
+
 interface RunContext {
   workflow:           Workflow
   allExtensions:      WorkflowExtension[]


### PR DESCRIPTION
## Files changed
src/areas/workflows/nodes/ImagePreviewNode.tsx — new (created + our update)
src/areas/workflows/WorkflowsPage.tsx — registration (1 line add)
src/areas/workflows/preflight.ts — registration (1 line add)

## New: ImagePreviewNode
A general single-image preview node for workflows. Reads the output file
from disk via `window.electron.fs.readFileBase64()` and renders as a
`data:` URL — avoids CSP issues and API origin dependency. Has a
pass-through image output so it can sit inline between nodes.

## Fix: text-only model detection
A model is text-only only if **all** its declared inputs are `"text"`.
Previously the check only looked at the first input, which incorrectly
treated multi-input models like Flux/Qwen (`"inputs": ["text", "image"]`)
as text-only and sent a 1×1 placeholder instead of the real image.

## Additional
- Simplified multi-input routing to use `src.outputType` instead of slot-based matching
- Added `extraParams.text` alongside `extraParams.prompt` for generator compatibility

----------------------------------------------------
<img width="981" height="601" alt="image" src="https://github.com/user-attachments/assets/06a85e1e-c795-4888-b6bd-e84f30afcc64" />

----------------------------------------------------
<img width="1727" height="688" alt="image" src="https://github.com/user-attachments/assets/9f78d0f4-b60a-41de-8231-e71ec24628a4" />
