### PR TITLE
fix: support WebP glTF mesh nodes

### DIFF
--- a/src/areas/workflows/nodes/mesh-exporter/package.json
+++ b/src/areas/workflows/nodes/mesh-exporter/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@gltf-transform/core": "^3.9.0"
+    "@gltf-transform/core": "^3.9.0",
+    "@gltf-transform/extensions": "^3.9.0"
   }
 }

--- a/src/areas/workflows/nodes/mesh-exporter/processor.ts
+++ b/src/areas/workflows/nodes/mesh-exporter/processor.ts
@@ -195,7 +195,8 @@ const processor = async (
   context.log(`Format: ${format} — input: ${input.filePath}`)
 
   const { NodeIO } = require('@gltf-transform/core')
-  const io = new NodeIO()
+  const { ALL_EXTENSIONS } = require('@gltf-transform/extensions')
+  const io = new NodeIO().registerExtensions(ALL_EXTENSIONS)
 
   context.progress(20, 'Loading mesh…')
   const doc = await io.read(input.filePath)

--- a/src/areas/workflows/nodes/mesh-optimizer/package.json
+++ b/src/areas/workflows/nodes/mesh-optimizer/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@gltf-transform/core": "^3.9.0",
+    "@gltf-transform/extensions": "^3.9.0",
     "@gltf-transform/functions": "^3.9.0",
     "meshoptimizer": "^0.22.0"
   }

--- a/src/areas/workflows/nodes/mesh-optimizer/processor.ts
+++ b/src/areas/workflows/nodes/mesh-optimizer/processor.ts
@@ -22,6 +22,7 @@ const processor = async (
 
   // Lazy requires — resolved from the extension's own node_modules
   const { NodeIO }             = require('@gltf-transform/core')
+  const { ALL_EXTENSIONS }     = require('@gltf-transform/extensions')
   const { simplify, weld }     = require('@gltf-transform/functions')
   const { MeshoptSimplifier }  = require('meshoptimizer')
 
@@ -29,7 +30,7 @@ const processor = async (
   await MeshoptSimplifier.ready
 
   context.progress(10, 'Loading mesh…')
-  const io  = new NodeIO()
+  const io  = new NodeIO().registerExtensions(ALL_EXTENSIONS)
   const doc = await io.read(input.filePath)
 
   // Count current triangles across all primitives


### PR DESCRIPTION
## Summary
- Register glTF Transform extensions when mesh workflow nodes read GLB files.
- Add @gltf-transform/extensions to mesh-optimizer and mesh-exporter node dependencies.
- Fixes Pixal3D GLBs that require EXT_texture_webp failing in Optimize Mesh / Mesh Exporter.

## Context
Pixal3D exports textured GLBs with EXT_texture_webp marked as required. Blender can open these files, but Modly mesh workflow nodes used bare NodeIO instances and failed with:

`Missing required extension, "EXT_texture_webp"`

## Changes
| File | Change |
|---|---|
| `src/areas/workflows/nodes/mesh-optimizer/processor.ts` | Register `ALL_EXTENSIONS` on `NodeIO`. |
| `src/areas/workflows/nodes/mesh-optimizer/package.json` | Add `@gltf-transform/extensions` dependency. |
| `src/areas/workflows/nodes/mesh-exporter/processor.ts` | Register `ALL_EXTENSIONS` on `NodeIO`. |
| `src/areas/workflows/nodes/mesh-exporter/package.json` | Add `@gltf-transform/extensions` dependency. |

## Test Plan
- [x] Ran focused Node test before removing temporary test scaffolding: `node --test --experimental-strip-types --experimental-loader ./scripts/node-ts-extensionless-loader.mjs src/areas/workflows/nodes/gltf-extension-registration.test.ts`
- [x] Ran `git diff --check`
- [ ] Full build not run.
