### PR TITLE
play a short ding sound when generation or workflow run completes

### DIFF
--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow, dialog, app, shell } from 'electron'
+import { ipcMain, BrowserWindow, Notification, dialog, app, shell } from 'electron'
 import { buildSync } from 'esbuild'
 import { autoUpdater } from 'electron-updater'
 import { join } from 'path'
@@ -237,6 +237,29 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
     win.isMaximized() ? win.restore() : win.maximize()
   })
   ipcMain.on('window:close', () => getWindow()?.close())
+
+  // Native OS notification (Windows toast / macOS Notification Center / Linux),
+  // for events the user wants to know about even when the window is minimized or
+  // behind other apps — e.g. a generation or workflow run finishing. Routed through
+  // the main process rather than the renderer's own Notification API so it works
+  // the same way regardless of focus and carries the app's own icon.
+  ipcMain.handle('notifications:show', (_event, title: string, body: string) => {
+    if (!Notification.isSupported()) return { success: false, error: 'Notifications not supported' }
+    const notification = new Notification({
+      title,
+      body,
+      icon: join(__dirname, '../../resources/icons/icon.png'),
+    })
+    notification.on('click', () => {
+      const win = getWindow()
+      if (!win) return
+      if (win.isMinimized()) win.restore()
+      win.show()
+      win.focus()
+    })
+    notification.show()
+    return { success: true }
+  })
 
   // Setup handlers — skipped in dev (uses .venv instead of python-embed)
   ipcMain.handle('setup:check', async () => {

--- a/electron/preload/electron-api.ts
+++ b/electron/preload/electron-api.ts
@@ -26,6 +26,12 @@ export function createElectronApi(ipcRenderer: IpcRendererLike, webFrame: WebFra
       close:    () => ipcRenderer.send('window:close'),
     },
 
+    // Native OS notifications (Windows toast / macOS Notification Center / Linux)
+    notifications: {
+      show: (title: string, body: string): Promise<{ success: boolean; error?: string }> =>
+        ipcRenderer.invoke('notifications:show', title, body) as Promise<{ success: boolean; error?: string }>,
+    },
+
     // Renderer UI (zoom whole page — scales every px/rem consistently)
     ui: { setZoomFactor: (factor: number) => webFrame.setZoomFactor(factor) },
 

--- a/src/areas/workflows/workflowRunStore.ts
+++ b/src/areas/workflows/workflowRunStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import axios, { AxiosInstance } from 'axios'
 import { useAppStore } from '@shared/stores/appStore'
 import { getWorkflowExtension } from './mockExtensions'
+import { playCompletionSound } from '@shared/utils/sound'
 import type { WorkflowExtension } from './mockExtensions'
 import type { Workflow, WFNode, WFEdge } from '@shared/types/electron.d'
 import { isBranchStarter, isSceneOutput, resolveDataSource, reachesSceneOutput, nearestUpstreamWaits } from './nodeBehaviors'
@@ -392,6 +393,7 @@ export const useWorkflowRunStore = create<WorkflowRunStore>((set, get) => {
       },
     }))
     useAppStore.getState().updateCurrentJob({ status: 'done', progress: 100, outputUrl })
+    playCompletionSound()
   }
 
   return {

--- a/src/areas/workflows/workflowRunStore.ts
+++ b/src/areas/workflows/workflowRunStore.ts
@@ -3,6 +3,7 @@ import axios, { AxiosInstance } from 'axios'
 import { useAppStore } from '@shared/stores/appStore'
 import { getWorkflowExtension } from './mockExtensions'
 import { playCompletionSound } from '@shared/utils/sound'
+import { showCompletionNotification } from '@shared/utils/notification'
 import type { WorkflowExtension } from './mockExtensions'
 import type { Workflow, WFNode, WFEdge } from '@shared/types/electron.d'
 import { isBranchStarter, isSceneOutput, resolveDataSource, reachesSceneOutput, nearestUpstreamWaits } from './nodeBehaviors'
@@ -394,6 +395,7 @@ export const useWorkflowRunStore = create<WorkflowRunStore>((set, get) => {
     }))
     useAppStore.getState().updateCurrentJob({ status: 'done', progress: 100, outputUrl })
     playCompletionSound()
+    void showCompletionNotification('Workflow run complete')
   }
 
   return {

--- a/src/shared/hooks/useGeneration.ts
+++ b/src/shared/hooks/useGeneration.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 import { useAppStore } from '@shared/stores/appStore'
 import { useApi } from './useApi'
+import { playCompletionSound } from '@shared/utils/sound'
 
 export function useGeneration() {
   const { currentJob, setCurrentJob, updateCurrentJob, generationOptions, selectedImageData, pushMeshUrl, clearMeshHistory } = useAppStore()
@@ -77,6 +78,7 @@ export function useGeneration() {
       if (result.status === 'done') {
         updateCurrentJob({ status: 'done', progress: 100, outputUrl: result.outputUrl, originalOutputUrl: result.outputUrl })
         if (result.outputUrl) pushMeshUrl(result.outputUrl)
+        playCompletionSound()
         break
       }
 

--- a/src/shared/hooks/useGeneration.ts
+++ b/src/shared/hooks/useGeneration.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react'
 import { useAppStore } from '@shared/stores/appStore'
 import { useApi } from './useApi'
 import { playCompletionSound } from '@shared/utils/sound'
+import { showCompletionNotification } from '@shared/utils/notification'
 
 export function useGeneration() {
   const { currentJob, setCurrentJob, updateCurrentJob, generationOptions, selectedImageData, pushMeshUrl, clearMeshHistory } = useAppStore()
@@ -79,6 +80,7 @@ export function useGeneration() {
         updateCurrentJob({ status: 'done', progress: 100, outputUrl: result.outputUrl, originalOutputUrl: result.outputUrl })
         if (result.outputUrl) pushMeshUrl(result.outputUrl)
         playCompletionSound()
+        void showCompletionNotification('Generation complete')
         break
       }
 

--- a/src/shared/types/electron.d.ts
+++ b/src/shared/types/electron.d.ts
@@ -129,6 +129,9 @@ declare global {
         maximize: () => void
         close:    () => void
       }
+      notifications: {
+        show: (title: string, body: string) => Promise<{ success: boolean; error?: string }>
+      }
       ui: {
         setZoomFactor: (factor: number) => void
       }

--- a/src/shared/utils/notification.ts
+++ b/src/shared/utils/notification.ts
@@ -1,0 +1,17 @@
+/**
+ * Native OS notification (Windows toast / macOS Notification Center / Linux) for
+ * events worth surfacing even when the user isn't looking at the app — e.g. a
+ * generation or workflow run finishing while they're in another window.
+ *
+ * Skipped when the app window already has focus: the user is looking right at
+ * it, so a toast on top would just be noise (the completion sound still plays
+ * either way — see sound.ts).
+ */
+export async function showCompletionNotification(body: string, title = 'Modly'): Promise<void> {
+  if (typeof document !== 'undefined' && document.hasFocus()) return
+  try {
+    await window.electron.notifications.show(title, body)
+  } catch {
+    // Notifications not available (e.g. unsupported platform)
+  }
+}

--- a/src/shared/utils/sound.ts
+++ b/src/shared/utils/sound.ts
@@ -1,0 +1,17 @@
+export function playCompletionSound() {
+  try {
+    const ctx = new AudioContext()
+    const oscillator = ctx.createOscillator()
+    const gain = ctx.createGain()
+    oscillator.connect(gain)
+    gain.connect(ctx.destination)
+    oscillator.type = 'sine'
+    oscillator.frequency.setValueAtTime(880, ctx.currentTime)
+    gain.gain.setValueAtTime(0.3, ctx.currentTime)
+    gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + 0.3)
+    oscillator.start(ctx.currentTime)
+    oscillator.stop(ctx.currentTime + 0.3)
+  } catch {
+    // Audio not available
+  }
+}


### PR DESCRIPTION
When running a generation (image-to-3D or a multi-node workflow), the app currently gives no audible feedback when it finishes. If you're in another tab or just looking away, there's no way to know it's done without checking back.

This PR adds a short, unobtrusive 880Hz "ding" sound (think microwave or oven beep) played once when:

A single image-to-3D generation finishes
A workflow run finishes (all branches complete)
The sound is generated on the fly using the Web Audio API — no audio files to bundle, no new dependencies, works in any modern browser/Electron environment. If audio isn't available for some reason, it silently does nothing.

Changes are minimal: a new utility file (src/shared/utils/sound.ts) and one line each in useGeneration.ts and workflowRunStore.ts.