### PR TITLE
fix(extensions): force UTF-8 worker stdio to prevent deadlock on non-UTF-8 Windows locales

### DIFF
--- a/api/services/extension_process.py
+++ b/api/services/extension_process.py
@@ -73,6 +73,10 @@ class ExtensionProcess:
         env["MODELS_DIR"]    = str(MODELS_DIR)
         env["WORKSPACE_DIR"] = str(WORKSPACE_DIR)
         env["MODLY_API_DIR"] = str(Path(__file__).parent.parent)
+        # Force UTF-8 for the worker's stdio regardless of the system locale.
+        # On non-UTF-8 Windows locales (cp932/cp936/cp949) the default encoding
+        # would otherwise mismatch our UTF-8 pipe readers and deadlock the worker.
+        env["PYTHONUTF8"] = "1"
         if sys.platform == "darwin":
             env.setdefault("NUMBA_DISABLE_JIT", "1")
         # Pass the exact model_dir so runner.py doesn't have to re-derive it
@@ -109,7 +113,8 @@ class ExtensionProcess:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
+                encoding="utf-8",
+                errors="replace",
                 bufsize=1,
                 env=self._build_env(),
             )
@@ -172,7 +177,8 @@ class ExtensionProcess:
                 check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
+                encoding="utf-8",
+                errors="replace",
             )
         except subprocess.CalledProcessError as exc:
             details = (exc.stderr or exc.stdout or "").strip()


### PR DESCRIPTION
## Contexte

Corrige #214 — la génération 3D se bloque indéfiniment sur Windows en locale non-UTF-8 (japonais/cp932, chinois, coréen). La barre de progression s'arrête vers 80 %, le worker consomme 0 % CPU et ne se termine jamais.

## Cause racine

Dans `api/services/extension_process.py`, le worker était lancé avec `subprocess.Popen(..., text=True)` **sans `encoding=` explicite**. Les pipes étaient donc décodés avec l'encodage système (cp932 au Japon). Le worker émet de l'UTF-8 → `UnicodeDecodeError` dès qu'un octet non-cp932 arrive → le thread lecteur `_stderr_loop` meurt → le buffer stderr se remplit → le worker se bloque dans `tqdm`. Blocage silencieux et permanent.

## Correction

- `_build_env()` : ajout de `PYTHONUTF8=1` pour que le worker émette de l'UTF-8 indépendamment de la locale.
- `Popen` (démarrage worker) et `subprocess.run` (install de module) : `encoding="utf-8", errors="replace"` en remplacement de `text=True`. `errors="replace"` garantit que les threads lecteurs (`_read_loop` / `_stderr_loop`) ne peuvent plus mourir sur un octet indécodable.

## Impact

Tous les utilisateurs Windows en locale non-UTF-8. Aucun changement de comportement sur les locales UTF-8. Suite de tests verte (pre-push).
