### PR TITLE
feat(extensions): per-slot text inputs, input labels, and file-select…

### DIFF
--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -677,6 +677,26 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
     }
   })
 
+  // List files (not directories) in a folder, optionally filtered by extension.
+  // `extensions` are lowercase without the dot (e.g. ['txt', 'png']).
+  ipcMain.handle('fs:listFiles', async (_, dirPath: string, extensions?: string[]) => {
+    try {
+      const wanted = extensions?.map(e => e.toLowerCase().replace(/^\./, ''))
+      const entries = await readdir(dirPath, { withFileTypes: true })
+      return entries
+        .filter(e => e.isFile())
+        .map(e => e.name)
+        .filter(name => {
+          if (!wanted || wanted.length === 0) return true
+          const ext = name.split('.').pop()?.toLowerCase() ?? ''
+          return wanted.includes(ext)
+        })
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    } catch {
+      return []
+    }
+  })
+
   ipcMain.handle('fs:moveDirectory', async (_, { src, dest }: { src: string; dest: string }) => {
     try {
       await mkdir(dest, { recursive: true })
@@ -757,6 +777,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       name?:             string
       input?:            'mesh' | 'image' | 'text' | 'audio'
       inputs?:           ('mesh' | 'image' | 'text' | 'audio')[]
+      input_labels?:     string[]
       output?:           'mesh' | 'image' | 'text' | 'audio'
       params_schema?:    unknown[]
       param_defaults?:   Record<string, unknown>
@@ -784,6 +805,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       name:           n.name ?? n.id,
       input:          n.input  ?? 'image' as const,
       inputs:         n.inputs,
+      inputLabels:    n.input_labels,
       output:         n.output ?? 'mesh'  as const,
       paramsSchema:   n.params_schema ?? parsed.params_schema ?? [],
       paramDefaults:  { ...(parsed.param_defaults ?? {}), ...(n.param_defaults ?? {}) },
@@ -1198,7 +1220,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
   })
 
   // Run a process extension in an isolated worker thread
-  ipcMain.handle('extensions:runProcess', async (_, extensionId: string, input: { filePath?: string; text?: string; nodeId?: string }, params: Record<string, unknown>) => {
+  ipcMain.handle('extensions:runProcess', async (_, extensionId: string, input: { filePath?: string; text?: string; texts?: (string | undefined)[]; nodeId?: string }, params: Record<string, unknown>) => {
     const userData        = app.getPath('userData')
     const { extensionsDir, workspaceDir } = getSettings(userData)
 

--- a/electron/main/process-runner.ts
+++ b/electron/main/process-runner.ts
@@ -49,6 +49,8 @@ parentPort.on('message', async (msg) => {
 export interface ProcessInput {
   filePath?: string
   text?:     string
+  /** Per-slot texts for multi-text-input nodes (index = target handle slot). */
+  texts?:    (string | undefined)[]
   nodeId?:   string
 }
 

--- a/electron/preload/electron-api.ts
+++ b/electron/preload/electron-api.ts
@@ -70,6 +70,8 @@ export function createElectronApi(ipcRenderer: IpcRendererLike, webFrame: WebFra
         ipcRenderer.invoke('fs:savePath', args) as Promise<string | null>,
       listDir:           (dirPath: string): Promise<string[]> =>
         ipcRenderer.invoke('fs:listDir', dirPath) as Promise<string[]>,
+      listFiles:         (dirPath: string, extensions?: string[]): Promise<string[]> =>
+        ipcRenderer.invoke('fs:listFiles', dirPath, extensions) as Promise<string[]>,
       moveDirectory:     (args: { src: string; dest: string }): Promise<{ success: boolean; error?: string }> =>
         ipcRenderer.invoke('fs:moveDirectory', args) as Promise<{ success: boolean; error?: string }>,
       deleteDirectory:   (dirPath: string): Promise<{ success: boolean; error?: string }> =>
@@ -221,7 +223,7 @@ export function createElectronApi(ipcRenderer: IpcRendererLike, webFrame: WebFra
 
       runProcess: (
         extensionId: string,
-        input:       { filePath?: string; text?: string; nodeId?: string },
+        input:       { filePath?: string; text?: string; texts?: (string | undefined)[]; nodeId?: string },
         params:      Record<string, unknown>,
       ): Promise<{ success: boolean; result?: { filePath?: string; text?: string }; error?: string }> =>
         ipcRenderer.invoke('extensions:runProcess', extensionId, input, params) as Promise<{ success: boolean; result?: { filePath?: string; text?: string }; error?: string }>,

--- a/src/areas/workflows/mockExtensions.ts
+++ b/src/areas/workflows/mockExtensions.ts
@@ -12,6 +12,7 @@ export interface WorkflowExtension {
   description:     string
   input:           'image' | 'text' | 'mesh' | 'audio'
   inputs?:         ('image' | 'text' | 'mesh' | 'audio')[]   // multi-input; overrides input when set
+  inputLabels?:    string[]                                  // display labels per input slot
   output:          'image' | 'text' | 'mesh' | 'audio'
   params:          ParamSchema[]
   builtin:         boolean
@@ -48,6 +49,7 @@ export function buildAllWorkflowExtensions(
         description:     ext.description ?? '',
         input:           node.input,
         inputs:          node.inputs,
+        inputLabels:     node.inputLabels,
         output:          node.output,
         params:          applyParamDefaults(node.paramsSchema as ParamSchema[], node.paramDefaults),
         builtin:         ext.builtin,
@@ -68,6 +70,7 @@ export function buildAllWorkflowExtensions(
         description:     ext.description ?? '',
         input:           node.input,
         inputs:          node.inputs,
+        inputLabels:     node.inputLabels,
         output:          node.output,
         params:          applyParamDefaults(node.paramsSchema as ParamSchema[], node.paramDefaults),
         builtin:         ext.builtin,

--- a/src/areas/workflows/nodes/ExtensionNode.tsx
+++ b/src/areas/workflows/nodes/ExtensionNode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useLayoutEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useLayoutEffect, useState } from 'react'
 import { Handle, Position, useReactFlow } from '@xyflow/react'
 import { useExtensionsStore } from '@shared/stores/extensionsStore'
 import { buildAllWorkflowExtensions } from '../mockExtensions'
@@ -76,11 +76,46 @@ function FloatInput({ value, onChange, className }: { value: number; onChange: (
   )
 }
 
-function ParamControl({ param, value, onChange }: {
+/** Dropdown of the files inside the folder held by another param (dir_from). */
+function FileSelectControl({ param, value, dirValue, onChange }: {
   param:    ParamSchema
-  value:    number | string
-  onChange: (v: number | string) => void
+  value:    string
+  dirValue: string
+  onChange: (v: string) => void
 }) {
+  const [files, setFiles] = useState<string[]>([])
+  const extsKey = (param.extensions ?? []).join(',')
+  useEffect(() => {
+    let alive = true
+    if (!dirValue) { setFiles([]); return }
+    window.electron.fs.listFiles(dirValue, param.extensions ?? undefined).then((list) => {
+      if (alive) setFiles(list)
+    }).catch(() => { if (alive) setFiles([]) })
+    return () => { alive = false }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dirValue, extsKey])
+
+  return (
+    <select value={value} disabled={!dirValue} onChange={(e) => onChange(e.target.value)}
+      className={`${inputCls} ${!dirValue ? 'opacity-50 cursor-not-allowed' : ''}`}>
+      <option value="">{!dirValue ? 'Pick a folder first…' : files.length === 0 ? 'No files found' : 'Select…'}</option>
+      {/* Keep a saved value visible even if it's no longer in the folder listing. */}
+      {value && !files.includes(value) && <option value={value}>{value} (missing)</option>}
+      {files.map((f) => <option key={f} value={f}>{f}</option>)}
+    </select>
+  )
+}
+
+function ParamControl({ param, value, onChange, resolvedParams }: {
+  param:          ParamSchema
+  value:          number | string
+  onChange:       (v: number | string) => void
+  resolvedParams: Record<string, unknown>
+}) {
+  if (param.type === 'file-select') {
+    const dirValue = String(resolvedParams[param.dir_from ?? ''] ?? '')
+    return <FileSelectControl param={param} value={String(value ?? '')} dirValue={dirValue} onChange={onChange} />
+  }
   if (param.type === 'select') {
     return (
       <select value={value} onChange={(e) => onChange(e.target.value)} className={inputCls}>
@@ -173,7 +208,7 @@ export default function ExtensionNode({ id, data, selected }: { id: string; data
     <div className="flex flex-col divide-y divide-zinc-800/40">
       <div ref={ioRowRef} className="flex items-center justify-between px-3 py-2">
         <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium border ${TAG_CLS[inputs[0]] ?? 'border-zinc-700 bg-zinc-800 text-zinc-400'}`}>
-          {inputs[0]}
+          {ext?.inputLabels?.[0] ?? inputs[0]}
         </span>
         {!isTerminal && (
           <>
@@ -188,7 +223,7 @@ export default function ExtensionNode({ id, data, selected }: { id: string; data
       </div>
       <div ref={ioRow2Ref} className="flex items-center px-3 py-2">
         <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium border ${TAG_CLS[inputs[1]] ?? 'border-zinc-700 bg-zinc-800 text-zinc-400'}`}>
-          {inputs[1]}
+          {ext?.inputLabels?.[1] ?? inputs[1]}
         </span>
       </div>
     </div>
@@ -257,17 +292,24 @@ export default function ExtensionNode({ id, data, selected }: { id: string; data
     >
       {hasParams && (
         <div className="px-3 pb-3 pt-2.5 flex flex-col gap-2">
-          {ext!.params.filter(isVisible).map((param) => {
-            const val = (data.params[param.id] ?? param.default) as number | string
-            return (
-              <div key={param.id} className="flex items-center gap-2">
-                <label className="text-[10px] text-zinc-500 w-24 shrink-0 leading-tight">{param.label}</label>
-                <div className="flex-1">
-                  <ParamControl param={param} value={val} onChange={(v) => patchParam(param.id, v)} />
-                </div>
-              </div>
+          {(() => {
+            // Effective values of every param (user value or schema default) —
+            // lets file-select params resolve their source folder (dir_from).
+            const resolvedParams = Object.fromEntries(
+              (ext?.params ?? []).map((p) => [p.id, data.params[p.id] ?? p.default]),
             )
-          })}
+            return ext!.params.filter(isVisible).map((param) => {
+              const val = (data.params[param.id] ?? param.default) as number | string
+              return (
+                <div key={param.id} className="flex items-center gap-2">
+                  <label className="text-[10px] text-zinc-500 w-24 shrink-0 leading-tight">{param.label}</label>
+                  <div className="flex-1">
+                    <ParamControl param={param} value={val} onChange={(v) => patchParam(param.id, v)} resolvedParams={resolvedParams} />
+                  </div>
+                </div>
+              )
+            })
+          })()}
         </div>
       )}
     </BaseNode>

--- a/src/areas/workflows/workflowRunStore.ts
+++ b/src/areas/workflows/workflowRunStore.ts
@@ -210,6 +210,9 @@ async function executeExtensionNode(
   let nodeInputPath:     string | undefined
   let nodeInputText:     string | undefined
   let nodeInputMeshPath: string | undefined
+  // Per-slot texts for multi-text-input nodes (e.g. positive/negative prompts).
+  // Indexed by target handle: input-0 → texts[0], input-1 → texts[1].
+  const nodeInputTexts: (string | undefined)[] = []
 
   const incomingEdges = workflow.edges.filter((e) => e.target === node.id)
 
@@ -220,7 +223,11 @@ async function executeExtensionNode(
       if (src.outputType === 'mesh')        nodeInputMeshPath = src.filePath
       else if (src.outputType === 'image')  nodeInputPath     = src.filePath
       else if (src.filePath !== undefined)  nodeInputPath     = src.filePath
-      if (src.text !== undefined && src.text.trim().length > 0) nodeInputText = src.text
+      if (src.text !== undefined && src.text.trim().length > 0) {
+        nodeInputText = src.text
+        const slot = /^input-(\d+)$/.exec(edge.targetHandle ?? '')
+        if (slot) nodeInputTexts[Number(slot[1])] = src.text
+      }
     }
   } else {
     for (const edge of incomingEdges) {
@@ -323,7 +330,12 @@ async function executeExtensionNode(
     const nid    = parts[1] ?? ''
     const result = await window.electron.extensions.runProcess(
       extId,
-      { filePath: nodeInputPath, text: nodeInputText, nodeId: nid },
+      {
+        filePath: nodeInputPath,
+        text:     nodeInputText,
+        texts:    nodeInputTexts.length > 0 ? nodeInputTexts : undefined,
+        nodeId:   nid,
+      },
       liveParams as Record<string, unknown>,
     )
     if (!result.success) throw new Error(result.error ?? 'Process extension failed')

--- a/src/shared/types/electron.d.ts
+++ b/src/shared/types/electron.d.ts
@@ -16,6 +16,7 @@ export interface ExtensionNode {
   name:             string
   input:            'image' | 'text' | 'mesh' | 'audio'
   inputs?:          ('image' | 'text' | 'mesh' | 'audio')[]   // multi-input nodes; overrides input when set
+  inputLabels?:     string[]   // display labels per input slot (e.g. positive/negative)
   output:           'image' | 'text' | 'mesh' | 'audio'
   paramsSchema:     ParamSchema[]
   paramDefaults?:   Record<string, number | string>
@@ -42,7 +43,7 @@ export interface ModelExtension {
 export interface ParamSchema {
   id:       string
   label:    string
-  type:     'select' | 'int' | 'float' | 'string'
+  type:     'select' | 'int' | 'float' | 'string' | 'file-select'
   default:  number | string
   options?: { value: number | string; label: string }[]
   min?:     number
@@ -50,6 +51,9 @@ export interface ParamSchema {
   step?:    number
   tooltip?: string
   show_if?: Record<string, string | number | (string | number)[]>
+  // file-select: dropdown of the files inside the folder held by another param
+  dir_from?:   string     // id of the (string) param holding the folder path
+  extensions?: string[]   // file extensions to list (e.g. ["json"])
 }
 
 export interface ProcessExtension {
@@ -74,6 +78,8 @@ export type AnyExtension = ModelExtension | ProcessExtension
 export interface ProcessInput {
   filePath?: string
   text?:     string
+  /** Per-slot texts for multi-text-input nodes (index = target handle slot). */
+  texts?:    (string | undefined)[]
   nodeId?:   string
 }
 
@@ -157,6 +163,7 @@ declare global {
         selectDirectory: (defaultPath?: string) => Promise<string | null>
         savePath:        (args: { filters: { name: string; extensions: string[] }[]; defaultPath?: string }) => Promise<string | null>
         listDir:         (dirPath: string) => Promise<string[]>
+        listFiles:       (dirPath: string, extensions?: string[]) => Promise<string[]>
         moveDirectory:   (args: { src: string; dest: string }) => Promise<{ success: boolean; error?: string }>
         deleteDirectory: (dirPath: string) => Promise<{ success: boolean; error?: string }>
         readScreenshotDataUrl: (filename: string) => Promise<string>


### PR DESCRIPTION
 Generic node/extension-system additions:
 - Multi-text-input routing: text inputs are delivered per target handle (ProcessInput.texts), so e.g. positive/negative prompts no longer overwrite each other.
 - input_labels in a node manifest to label each input handle.
 - New file-select param type: a dropdown of the files in a folder held by another param (dir_from + extensions).

 Note: includes the shared fs.listFiles helper (also in the For Each PR) — trivial conflict on merge if that lands first.