### PR TITLE
fix: harden extension installs — crash recovery, corrupted-state UX, pip cache

### DIFF
--- a/api/services/generator_registry.py
+++ b/api/services/generator_registry.py
@@ -58,6 +58,14 @@ def _discover_extensions() -> Dict[str, Tuple[type, dict]]:
     for ext_dir in sorted(EXTENSIONS_DIR.iterdir()):
         if not ext_dir.is_dir():
             continue
+        # Dot-dirs are install machinery (staging/backup), never extensions
+        if ext_dir.name.startswith("."):
+            continue
+        # Marker left by the installer while setup runs (or after a crash):
+        # the folder is not ready to be loaded
+        if (ext_dir / ".modly-incomplete").exists():
+            print(f"[Registry] Skipping '{ext_dir.name}': install has not completed")
+            continue
 
         manifest_path  = ext_dir / "manifest.json"
         generator_path = ext_dir / "generator.py"

--- a/electron/main/extension-path-guard.test.ts
+++ b/electron/main/extension-path-guard.test.ts
@@ -44,9 +44,32 @@ test('resolvePathWithinRoot rejects canonical escapes', async () => {
   assert.throws(() => resolvePathWithinRoot(root, '../escape'), /escapes root/i)
 })
 
+test('resolvePathWithinRoot rejects leaves that resolve to the root itself', async () => {
+  const { resolvePathWithinRoot } = await loadGuard()
+  const root = path.join('/tmp', 'extensions-root')
+  assert.throws(() => resolvePathWithinRoot(root, '.'), /escapes root/i)
+  assert.throws(() => resolvePathWithinRoot(root, ''), /escapes root/i)
+})
+
+test('parseExtensionBackupName extracts ids with dashes and rejects foreign names', async () => {
+  const { parseExtensionBackupName } = await loadGuard()
+  assert.deepEqual(parseExtensionBackupName('.modly-backup-hunyuan3d-mini-1752580000000'), { extensionId: 'hunyuan3d-mini' })
+  assert.deepEqual(parseExtensionBackupName('.modly-backup-x-1'), { extensionId: 'x' })
+  assert.equal(parseExtensionBackupName('.modly-backup-noTimestamp'), null)
+  assert.equal(parseExtensionBackupName('.modly-staging-x-1'), null)
+  assert.equal(parseExtensionBackupName('regular-extension'), null)
+})
+
 test('buildExtensionBackupPath stays within root and rejects unsafe ids', async () => {
   const { buildExtensionBackupPath } = await loadGuard()
   const root = path.join('/tmp', 'extensions-root')
   assert.equal(buildExtensionBackupPath(root, 'mesh-process', '123'), path.resolve(root, '.modly-backup-mesh-process-123'))
   assert.throws(() => buildExtensionBackupPath(root, '../escape', '123'), /path separators/i)
+})
+
+test('buildExtensionStagingPath stays within root and rejects unsafe ids', async () => {
+  const { buildExtensionStagingPath } = await loadGuard()
+  const root = path.join('/tmp', 'extensions-root')
+  assert.equal(buildExtensionStagingPath(root, 'mesh-process', '42'), path.resolve(root, '.modly-staging-mesh-process-42'))
+  assert.throws(() => buildExtensionStagingPath(root, '../escape', '42'), /path separators/i)
 })

--- a/electron/main/extension-path-guard.ts
+++ b/electron/main/extension-path-guard.ts
@@ -36,7 +36,9 @@ export function resolvePathWithinRoot(rootDir: string, unsafeLeaf: string): stri
   const resolvedCandidate = resolvePath(resolvedRoot, unsafeLeaf)
   const normalizedRelative = relative(resolvedRoot, resolvedCandidate).replace(/\\/g, '/')
 
-  if (normalizedRelative === '..' || normalizedRelative.startsWith('../') || isAbsolute(normalizedRelative)) {
+  // An empty relative path means the leaf resolved to the root itself ('', '.')
+  // — never a valid child, and catastrophic for deletion call sites.
+  if (normalizedRelative === '' || normalizedRelative === '..' || normalizedRelative.startsWith('../') || isAbsolute(normalizedRelative)) {
     throw new Error(`Resolved path escapes root: ${unsafeLeaf}`)
   }
 
@@ -47,7 +49,45 @@ export function resolveExtensionPathWithinRoot(rootDir: string, extensionId: unk
   return resolvePathWithinRoot(rootDir, assertSafeExtensionId(extensionId))
 }
 
+// ─── Internal (non-extension) dir names inside extensionsDir ─────────────────
+// Extension ids can never start with a dot, so dot-prefixed names are reserved
+// for install machinery: staging copies, backups of the previous version.
+// Both the Electron and Python discovery sides must skip them.
+
+export const EXT_BACKUP_PREFIX  = '.modly-backup-'
+export const EXT_STAGING_PREFIX = '.modly-staging-'
+// Marker file inside an extension folder while its setup is still running —
+// presence after a crash means the install never completed.
+export const EXT_INCOMPLETE_MARKER = '.modly-incomplete'
+
+export function isInternalExtensionDirName(name: string): boolean {
+  return name.startsWith('.')
+}
+
 export function buildExtensionBackupPath(rootDir: string, extensionId: unknown, suffix: string): string {
   const safeId = assertSafeExtensionId(extensionId)
-  return resolvePathWithinRoot(rootDir, `.modly-backup-${safeId}-${suffix}`)
+  return resolvePathWithinRoot(rootDir, `${EXT_BACKUP_PREFIX}${safeId}-${suffix}`)
+}
+
+// A backup dir is the previous version of an extension, parked during an
+// install swap. Its name embeds the extension id: .modly-backup-<id>-<ts>.
+// Ids may contain '-', so strip the numeric timestamp suffix, not a naive split.
+export function parseExtensionBackupName(name: string): { extensionId: string } | null {
+  if (!name.startsWith(EXT_BACKUP_PREFIX)) return null
+  const rest  = name.slice(EXT_BACKUP_PREFIX.length)
+  const match = rest.match(/^(.+)-\d+$/)
+  if (!match) return null
+  try {
+    return { extensionId: assertSafeExtensionId(match[1]) }
+  } catch {
+    return null
+  }
+}
+
+// Staging dir lives next to the final location so activation is a same-volume
+// atomic rename. Unique per attempt (suffix) so a new install can never merge
+// into the leftovers of a previous one, and never races the startup purge.
+export function buildExtensionStagingPath(rootDir: string, extensionId: unknown, suffix: string): string {
+  const safeId = assertSafeExtensionId(extensionId)
+  return resolvePathWithinRoot(rootDir, `${EXT_STAGING_PREFIX}${safeId}-${suffix}`)
 }

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -3,7 +3,7 @@ import { buildSync } from 'esbuild'
 import { autoUpdater } from 'electron-updater'
 import { join } from 'path'
 import { rm as rmAsync, readFile, writeFile, mkdir, readdir, rename, cp, symlink, lstat } from 'fs/promises'
-import { existsSync, readdirSync, statSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, statSync } from 'fs'
 import axios from 'axios'
 import * as tar from 'tar'
 import * as os from 'os'
@@ -20,8 +20,19 @@ import { logger } from './logger'
 import { getProcessRunner, getPythonProcessRunner, getExtPythonExe, terminateProcessRunner, terminateAllProcessRunners } from './process-runner'
 import { getBuiltinExtensionsDir } from './builtin-sync'
 import { spawn, execFile } from 'child_process'
-import { assertSafeExtensionId, buildExtensionBackupPath, resolveExtensionPathWithinRoot } from './extension-path-guard'
-import { isSetupFailureFatal, validateInstallManifest } from './extension-install-utils'
+import {
+  EXT_BACKUP_PREFIX,
+  EXT_INCOMPLETE_MARKER,
+  EXT_STAGING_PREFIX,
+  assertSafeExtensionId,
+  buildExtensionBackupPath,
+  buildExtensionStagingPath,
+  isInternalExtensionDirName,
+  parseExtensionBackupName,
+  resolveExtensionPathWithinRoot,
+  resolvePathWithinRoot,
+} from './extension-path-guard'
+import { validateInstallManifest } from './extension-install-utils'
 import { registerWorkspaceAssetLibraryIpcHandlers } from './artifact-registry-service'
 import { updatesSupported } from './updater'
 
@@ -90,6 +101,12 @@ function runExtensionSetup(
     const pythonExe = getVenvPythonExe(userData)
     const setupPy   = join(extDir, 'setup.py')
 
+    // Shared pip wheel cache: a failed setup retried later reuses the multi-GB
+    // torch wheels instead of re-downloading them (see issue #223). Extension
+    // setup.py scripts that pass --no-cache-dir get it stripped by the launcher.
+    const pipCacheDir = join(getSettings(userData).dependenciesDir, 'pip-cache')
+    try { mkdirSync(pipCacheDir, { recursive: true }) } catch { /* pip creates it too */ }
+
     const accelerator = process.platform === 'darwin' && process.arch === 'arm64' ? 'mps' : gpuSm > 0 ? 'cuda' : 'cpu'
     const args = JSON.stringify({
       python_exe: pythonExe,
@@ -150,22 +167,41 @@ def _rewrite_command(command):
         return rewritten
     return command
 
+def _is_pip_command(command):
+    if not isinstance(command, (list, tuple)):
+        return False
+    return any("pip" in str(part).lower() for part in command[:3])
+
+def _strip_no_cache(command):
+    # Extension setup scripts often hardcode --no-cache-dir, which forces pip to
+    # re-download multi-GB wheels on every retry. Modly provides a shared cache
+    # via PIP_CACHE_DIR, so drop the flag and let pip use it.
+    if not _is_pip_command(command):
+        return command
+    if not any(str(part) == "--no-cache-dir" for part in command):
+        return command
+    print("[Modly setup compat] Removed --no-cache-dir so pip reuses the shared wheel cache.", file=sys.stderr)
+    return [part for part in command if str(part) != "--no-cache-dir"]
+
+def _transform_command(command):
+    return _strip_no_cache(_rewrite_command(command))
+
 def _patched_run(*args, **kwargs):
     args = list(args)
     if args:
-        args[0] = _rewrite_command(args[0])
+        args[0] = _transform_command(args[0])
     return _original_run(*args, **kwargs)
 
 def _patched_check_call(*args, **kwargs):
     args = list(args)
     if args:
-        args[0] = _rewrite_command(args[0])
+        args[0] = _transform_command(args[0])
     return _original_check_call(*args, **kwargs)
 
 def _patched_check_output(*args, **kwargs):
     args = list(args)
     if args:
-        args[0] = _rewrite_command(args[0])
+        args[0] = _transform_command(args[0])
     return _original_check_output(*args, **kwargs)
 
 subprocess.run = _patched_run
@@ -177,6 +213,7 @@ runpy.run_path(setup_py, run_name="__main__")
 `
     const proc = spawn(pythonExe, ['-c', launcher, setupPy, args], {
       stdio: ['ignore', 'pipe', 'pipe'],
+      env:   { ...process.env, PIP_CACHE_DIR: pipCacheDir },
     })
 
     const handleLine = (line: string) => { if (line) onLog?.(line) }
@@ -197,7 +234,91 @@ runpy.run_path(setup_py, run_name="__main__")
   })
 }
 
+// ─── Robust directory removal / rename ────────────────────────────────────────
+// On Windows the first attempt routinely fails with EBUSY/EPERM while the
+// antivirus or a dying python process still holds files open — which used to
+// leave half-deleted extension folders behind. Locked errors are retried with
+// a progressive backoff; any other error fails immediately.
+
+const FS_RETRY_DELAYS_MS = [200, 500, 1500, 2500]
+
+function isLockedFsError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException).code
+  return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES'
+}
+
+type FsRetryResult = { ok: true } | { ok: false; locked: boolean; error: unknown }
+
+async function fsWithRetry(op: () => Promise<void>, label: string, target: string): Promise<FsRetryResult> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await op()
+      return { ok: true }
+    } catch (err) {
+      if (!isLockedFsError(err) || attempt === FS_RETRY_DELAYS_MS.length) {
+        logger.warn(`[${label}] ${target}: ${err}`)
+        return { ok: false, locked: isLockedFsError(err), error: err }
+      }
+      await new Promise((r) => setTimeout(r, FS_RETRY_DELAYS_MS[attempt]))
+    }
+  }
+}
+
+const rmWithRetry = (path: string, label: string): Promise<FsRetryResult> =>
+  fsWithRetry(() => rmAsync(path, { recursive: true, force: true }), label, path)
+
+const renameWithRetry = (from: string, to: string, label: string): Promise<FsRetryResult> =>
+  fsWithRetry(() => rename(from, to), label, `${from} -> ${to}`)
+
+// Extension ids with an install currently in flight. Their folder carries the
+// incomplete marker during setup — extensions:list must not report it as
+// corrupted while the install is legitimately running.
+const activeExtensionInstalls = new Set<string>()
+
 export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGetter): void {
+  // Reconcile leftovers of interrupted installs. No install can be in flight
+  // this early in the app's life, so anything matching is stale:
+  //  - staging dirs → discard (never the only copy of anything)
+  //  - extension dir still carrying the incomplete marker + a backup exists
+  //    → the install crashed mid-setup: put the previous version back
+  //  - backup dirs → restore if the extension folder is gone, else discard
+  void (async () => {
+    try {
+      const extensionsDir = getSettings(app.getPath('userData')).extensionsDir
+      const entries = await readdir(extensionsDir, { withFileTypes: true })
+      const names   = entries.map((e) => e.name)
+
+      await Promise.allSettled(
+        names
+          .filter((n) => n.startsWith(EXT_STAGING_PREFIX))
+          .map((n) => rmWithRetry(join(extensionsDir, n), 'ext-cleanup')),
+      )
+
+      // Newest backup first, so the most recent good version wins a restore
+      const backups = names.filter((n) => n.startsWith(EXT_BACKUP_PREFIX)).sort().reverse()
+      for (const name of backups) {
+        const backupPath = join(extensionsDir, name)
+        const parsed = parseExtensionBackupName(name)
+        if (!parsed) { await rmWithRetry(backupPath, 'ext-cleanup'); continue }
+
+        const destDir        = join(extensionsDir, parsed.extensionId)
+        const destIncomplete = existsSync(join(destDir, EXT_INCOMPLETE_MARKER))
+        if (existsSync(destDir) && !destIncomplete) {
+          // Install completed; only the backup's own cleanup had failed
+          await rmWithRetry(backupPath, 'ext-cleanup')
+          continue
+        }
+        // Crash mid-swap or mid-setup: this backup is the last good copy
+        if (destIncomplete) {
+          const removed = await rmWithRetry(destDir, 'ext-restore')
+          if (!removed.ok) continue   // keep the backup; retried next launch
+        }
+        const restored = await renameWithRetry(backupPath, destDir, 'ext-restore')
+        if (restored.ok) logger.info(`[ext-restore] restored "${parsed.extensionId}" from ${name}`)
+      }
+    } catch { /* best-effort; extensionsDir may not exist yet */ }
+  })()
+
   const activeDownloads = new Map<string, { percent: number; file?: string; fileIndex?: number; totalFiles?: number }>()
   // Logging from renderer
   ipcMain.on('log:error', (_event, message: string) => logger.error(`[Renderer] ${message}`))
@@ -367,28 +488,14 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
     }
 
     // Retry removal — Windows may return EBUSY/EPERM if handles linger
-    const maxRetries = 3
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        await rmAsync(modelDir, { recursive: true, force: true })
-        return { success: true }
-      } catch (err: unknown) {
-        const code = (err as NodeJS.ErrnoException).code
-        const isLocked = code === 'EBUSY' || code === 'EPERM'
-        if (isLocked && attempt < maxRetries) {
-          await new Promise(resolve => setTimeout(resolve, 1_000 * attempt))
-          continue
-        }
-        return {
-          success: false,
-          error: isLocked
-            ? `Model files are still locked after ${maxRetries} attempts. Close any programs using the model and try again.`
-            : String(err),
-        }
-      }
+    const removed = await rmWithRetry(modelDir, 'model-delete')
+    if (removed.ok) return { success: true }
+    return {
+      success: false,
+      error: removed.locked
+        ? 'Model files are still locked after several attempts. Close any programs using the model and try again.'
+        : String(removed.error),
     }
-
-    return { success: false, error: 'Unexpected error during deletion' }
   })
 
   ipcMain.handle('model:showInFolder', (_, modelId: string) => {
@@ -847,15 +954,24 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
         // On Windows, junction points are reported by Node.js as isSymbolicLink()=true,
         // isDirectory()=false. Use statSync (which follows links) as the authoritative check.
         const dirs = entries.filter(e => {
+          // Staging/backup dirs are never extensions (ids can't start with '.')
+          if (isInternalExtensionDirName(e.name)) return false
           if (e.isDirectory()) return true
           if (e.isSymbolicLink()) {
             try { return statSync(join(dir, e.name)).isDirectory() } catch { return false }
           }
           return false
         })
-        return Promise.all(dirs.map(async (entry) => {
-          const base = { type: 'model' as const, id: entry.name, name: entry.name, trusted: isBuiltin, builtin: isBuiltin, nodes: [] }
+        const results = await Promise.all(dirs.map(async (entry) => {
           const entryPath = join(dir, entry.name)
+          const skeleton  = { type: 'model' as const, id: entry.name, name: entry.name, trusted: isBuiltin, builtin: isBuiltin, nodes: [], corrupted: true }
+
+          // Marker still present → an install of this folder never completed.
+          // Hidden entirely while that install is still in flight.
+          if (existsSync(join(entryPath, EXT_INCOMPLETE_MARKER))) {
+            if (activeExtensionInstalls.has(entry.name)) return null
+            return { ...skeleton, manifestError: 'incomplete' as const }
+          }
 
           // Detect local extensions: check for .modly-local sentinel
           let localSourcePath: string | undefined
@@ -868,6 +984,9 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
             }
           }
 
+          // 'missing' = no manifest at all (gutted folder); 'invalid' = a manifest
+          // exists but doesn't parse (fixable by hand, don't push deletion only)
+          let manifestError: 'missing' | 'invalid' = 'missing'
           for (const manifestFile of ['manifest.json', 'package.json']) {
             const p = join(entryPath, manifestFile)
             if (existsSync(p)) {
@@ -877,11 +996,12 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
                 // Inject local:// source so the UI shows the Local badge
                 if (localSourcePath) parsed.source = `local://${localSourcePath}`
                 return parseExtensionManifest(parsed, entry.name, trustedRepos, isBuiltin)
-              } catch { /* ignore parse errors, fall through */ }
+              } catch { manifestError = 'invalid' }
             }
           }
-          return base
+          return { ...skeleton, manifestError }
         }))
+        return results.filter((e): e is Exclude<typeof e, null> => e !== null)
       } catch {
         return []
       }
@@ -904,6 +1024,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
 
     let tarPath    = ''
     let extractDir = ''
+    let trackedExtensionId = ''
 
     try {
       // 1. Parse and validate GitHub URL
@@ -959,109 +1080,136 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       if (!hasNodes) throw new Error('manifest.json: required field "nodes" missing or empty')
       const extensionId = assertSafeExtensionId(rawManifestId)
       manifest.id = extensionId
+      trackedExtensionId = extensionId
+      activeExtensionInstalls.add(extensionId)
 
       // Override source field with the actual GitHub URL so trust is based on origin
       manifest.source = `https://github.com/${owner}/${repo}`
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
 
-      // 5. Copy to extensions directory (overwrite if already present)
+      // 5. Stage into a fresh, unique dir next to the final location (so a new
+      //    attempt can never merge into leftovers of a previous one), mark it
+      //    incomplete, and swap it in with atomic renames BEFORE the long setup
+      //    phase. setup.py then runs in the final path — venvs record absolute
+      //    paths, so the folder must not move after setup. If anything dies
+      //    mid-way, the marker + backup let the startup reconciler put the
+      //    previous version back.
       const extensionsDir = getSettings(app.getPath('userData')).extensionsDir
       await mkdir(extensionsDir, { recursive: true })
-      const destDir = resolveExtensionPathWithinRoot(extensionsDir, extensionId)
-      const backupDir = existsSync(destDir) ? buildExtensionBackupPath(extensionsDir, extensionId, String(Date.now())) : null
+      const destDir    = resolveExtensionPathWithinRoot(extensionsDir, extensionId)
+      const stagingDir = buildExtensionStagingPath(extensionsDir, extensionId, String(Date.now()))
 
       try {
+        await cp(extractDir, stagingDir, { recursive: true })
+        await writeFile(join(stagingDir, EXT_INCOMPLETE_MARKER), new Date().toISOString(), 'utf-8')
+
+        // Compile TypeScript entry to JS at install time (once, no runtime overhead)
+        if (isProcess && entryFile.endsWith('.ts')) {
+          emit({ step: 'setting_up', message: 'Compiling TypeScript entry…' })
+          const compiledEntry = entryFile.replace(/\.ts$/, '.js')
+          buildSync({
+            entryPoints: [join(stagingDir, entryFile)],
+            outfile:     join(stagingDir, compiledEntry),
+            bundle:      true,
+            platform:    'node',
+            format:      'cjs',
+            external:    ['electron'],
+          })
+          manifest.entry = compiledEntry
+          await writeFile(join(stagingDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf-8')
+        }
+      } catch (stageErr) {
+        await rmWithRetry(stagingDir, 'ext-install')
+        throw stageErr
+      }
+
+      // 6. Swap into place (backup the previous version first)
+      terminateProcessRunner(extensionId)
+      const backupDir = existsSync(destDir) ? buildExtensionBackupPath(extensionsDir, extensionId, String(Date.now())) : null
       if (backupDir) {
-        terminateProcessRunner(extensionId)
-        await rename(destDir, backupDir)
+        const parked = await renameWithRetry(destDir, backupDir, 'ext-install')
+        if (!parked.ok) {
+          await rmWithRetry(stagingDir, 'ext-install')
+          throw new Error('The current extension folder is locked (antivirus or a running process) — close what might be using it and try again.')
+        }
       }
-      await cp(extractDir, destDir, { recursive: true })
-
-      // Compile TypeScript entry to JS at install time (once, no runtime overhead)
-      if (isProcess && entryFile.endsWith('.ts')) {
-        emit({ step: 'setting_up', message: 'Compiling TypeScript entry…' })
-        const compiledEntry = entryFile.replace(/\.ts$/, '.js')
-        buildSync({
-          entryPoints: [join(destDir, entryFile)],
-          outfile:     join(destDir, compiledEntry),
-          bundle:      true,
-          platform:    'node',
-          format:      'cjs',
-          external:    ['electron'],
-        })
-        manifest.entry = compiledEntry
-        await writeFile(join(destDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf-8')
+      const activated = await renameWithRetry(stagingDir, destDir, 'ext-install')
+      if (!activated.ok) {
+        await rmWithRetry(stagingDir, 'ext-install')
+        if (backupDir) await renameWithRetry(backupDir, destDir, 'ext-install')
+        throw new Error('Could not move the staged extension into place — the folder is locked. Try again.')
       }
 
-      if (isPythonProcess) {
-        // 6a. Python process extension: run setup.py if present (same as model extensions)
-        if (existsSync(join(destDir, 'setup.py'))) {
-          emit({ step: 'setting_up', message: 'Setting up Python environment…' })
-          const { sm: gpuSm, cudaVersion } = await detectGpuInfo()
-          try {
+      // 7. Setup runs in the final folder; a failure restores the previous version
+      try {
+        if (isPythonProcess) {
+          // 7a. Python process extension: run setup.py if present (same as model extensions)
+          if (existsSync(join(destDir, 'setup.py'))) {
+            emit({ step: 'setting_up', message: 'Setting up Python environment…' })
+            const { sm: gpuSm, cudaVersion } = await detectGpuInfo()
             await runExtensionSetup(destDir, gpuSm, cudaVersion, (line) => {
               logger.info(`[ext-setup] ${line}`)
               emit({ step: 'setting_up', message: line })
             })
-          } catch (err) {
-            if (isSetupFailureFatal({ isProcess, isPythonProcess })) {
-              throw new Error(`Extension setup failed: ${err}`)
-            }
-            logger.warn(`[ext-setup] setup.py failed: ${err}`)
-            emit({ step: 'setting_up', message: `Warning: setup failed — ${err}` })
+          }
+        } else if (isProcess) {
+          // 7b. JS process extension: npm install if package.json present
+          if (existsSync(join(destDir, 'package.json'))) {
+            emit({ step: 'setting_up', message: 'Installing dependencies…' })
+            await new Promise<void>((resolve, reject) => {
+              const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+              const child = spawn(npm, ['install', '--omit=dev', '--no-audit', '--no-fund'], {
+                cwd:   destDir,
+                stdio: 'pipe',
+              })
+              let buf = ''
+              const onData = (chunk: Buffer) => {
+                buf += chunk.toString()
+                const lines = buf.split('\n')
+                buf = lines.pop() ?? ''
+                for (const raw of lines) {
+                  const line = raw.replace(/\x1b\[[0-9;]*m/g, '').trim()
+                  if (line) emit({ step: 'setting_up', message: line })
+                }
+              }
+              child.stdout?.on('data', onData)
+              child.stderr?.on('data', onData)
+              child.on('close', (code) => code === 0 ? resolve() : reject(new Error(`npm install failed (exit ${code})`)))
+              child.on('error', reject)
+            })
+          }
+        } else {
+          // 7c. Model extension: run setup.py directly (no FastAPI required)
+          if (existsSync(join(destDir, 'setup.py'))) {
+            emit({ step: 'setting_up', message: 'Setting up Python environment…' })
+            const { sm: gpuSm, cudaVersion } = await detectGpuInfo()
+            await runExtensionSetup(destDir, gpuSm, cudaVersion, (line) => {
+              logger.info(`[ext-setup] ${line}`)
+              emit({ step: 'setting_up', message: line })
+            })
           }
         }
-      } else if (isProcess) {
-        // 6b. JS process extension: npm install if package.json present
-        if (existsSync(join(destDir, 'package.json'))) {
-          emit({ step: 'setting_up', message: 'Installing dependencies…' })
-          await new Promise<void>((resolve, reject) => {
-            const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-            const child = spawn(npm, ['install', '--omit=dev', '--no-audit', '--no-fund'], {
-              cwd:   destDir,
-              stdio: 'pipe',
-            })
-            let buf = ''
-            const onData = (chunk: Buffer) => {
-              buf += chunk.toString()
-              const lines = buf.split('\n')
-              buf = lines.pop() ?? ''
-              for (const raw of lines) {
-                const line = raw.replace(/\x1b\[[0-9;]*m/g, '').trim()
-                if (line) emit({ step: 'setting_up', message: line })
-              }
-            }
-            child.stdout?.on('data', onData)
-            child.stderr?.on('data', onData)
-            child.on('close', (code) => code === 0 ? resolve() : reject(new Error(`npm install failed (exit ${code})`)))
-            child.on('error', reject)
-          })
-        }
-      } else {
-        // 6b. Model extension: run setup.py directly (no FastAPI required)
-        if (existsSync(join(destDir, 'setup.py'))) {
-          emit({ step: 'setting_up', message: 'Setting up Python environment…' })
-          const { sm: gpuSm, cudaVersion } = await detectGpuInfo()
-          await runExtensionSetup(destDir, gpuSm, cudaVersion, (line) => {
-            logger.info(`[ext-setup] ${line}`)
-            emit({ step: 'setting_up', message: line })
-          })
-        }
+      } catch (setupErr) {
+        // Discard the half-set-up folder and put the previous version back. If
+        // the folder is locked, the marker keeps it flagged corrupted and the
+        // startup reconciler restores the backup on next launch.
+        const discarded = await rmWithRetry(destDir, 'ext-install')
+        if (discarded.ok && backupDir) await renameWithRetry(backupDir, destDir, 'ext-install')
+        throw setupErr
+      }
 
+      // 8. Success: clear the marker, then drop the backup. The backup is only
+      //    discarded once the marker is confirmed gone — a still-marked folder
+      //    would make the startup reconciler restore the backup over this
+      //    freshly completed install.
+      const markerGone = await rmWithRetry(join(destDir, EXT_INCOMPLETE_MARKER), 'ext-install')
+      if (backupDir && markerGone.ok) void rmWithRetry(backupDir, 'ext-install')
+
+      // Hot-reload Python so it picks up the new/updated model extension
+      if (!isProcess) {
         try {
           await axios.post(`${API_BASE_URL}/extensions/reload`, {}, { timeout: 10_000 })
         } catch { /* Python might not be running yet */ }
-      }
-
-      if (backupDir) {
-        await rmAsync(backupDir, { recursive: true, force: true })
-      }
-      } catch (installErr) {
-        await rmAsync(destDir, { recursive: true, force: true }).catch(() => {})
-        if (backupDir && existsSync(backupDir)) {
-          await rename(backupDir, destDir)
-        }
-        throw installErr
       }
 
       emit({ step: 'done', extensionId })
@@ -1074,6 +1222,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       emit({ step: 'error', message: String(err) })
       return { success: false, error: String(err) }
     } finally {
+      if (trackedExtensionId) activeExtensionInstalls.delete(trackedExtensionId)
       // Cleanup temp files
       if (tarPath    && existsSync(tarPath))    rmAsync(tarPath,    { force: true }).catch(() => {})
       if (extractDir && existsSync(extractDir)) rmAsync(extractDir, { recursive: true, force: true }).catch(() => {})
@@ -1082,20 +1231,33 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
 
   // Uninstall an extension — built-ins cannot be uninstalled
   ipcMain.handle('extensions:uninstall', async (_, extensionId: string) => {
-    const userData      = app.getPath('userData')
-    const safeExtensionId = assertSafeExtensionId(extensionId)
-    const builtinPath   = resolveExtensionPathWithinRoot(getBuiltinExtensionsDir(), safeExtensionId)
-    if (existsSync(builtinPath)) {
-      return { success: false, error: `"${safeExtensionId}" is a built-in extension and cannot be uninstalled.` }
-    }
-
-    const extensionsDir = getSettings(userData).extensionsDir
-    const extPath       = resolveExtensionPathWithinRoot(extensionsDir, safeExtensionId)
     try {
-      // Terminate process runner if it's a process extension
-      terminateProcessRunner(safeExtensionId)
+      // Corrupted folders can carry arbitrary names (manual copies, failed
+      // unzips), so only enforce root confinement for the deletion path. The
+      // strict id pattern still guards the built-in check — a non-conforming
+      // name can never be a built-in.
+      const extensionsDir = getSettings(app.getPath('userData')).extensionsDir
+      const extPath       = resolvePathWithinRoot(extensionsDir, String(extensionId))
 
-      await rmAsync(extPath, { recursive: true, force: true })
+      try {
+        const safeExtensionId = assertSafeExtensionId(extensionId)
+        if (existsSync(resolveExtensionPathWithinRoot(getBuiltinExtensionsDir(), safeExtensionId))) {
+          return { success: false, error: `"${safeExtensionId}" is a built-in extension and cannot be uninstalled.` }
+        }
+      } catch { /* non-conforming folder name → not a built-in */ }
+
+      // Terminate process runner if it's a process extension
+      terminateProcessRunner(extensionId)
+
+      const removed = await rmWithRetry(extPath, 'ext-uninstall')
+      if (!removed.ok) {
+        return {
+          success: false,
+          error: removed.locked
+            ? 'Could not delete the extension folder — a file inside it is locked (antivirus or a running process). Close what might be using it and try again.'
+            : String(removed.error),
+        }
+      }
       // Hot-reload Python so it stops using the deleted model extension
       try {
         await axios.post(`${API_BASE_URL}/extensions/reload`, {}, { timeout: 10_000 })
@@ -1112,7 +1274,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       const safeExtensionId = assertSafeExtensionId(extensionId)
       const extDir = resolveExtensionPathWithinRoot(getSettings(app.getPath('userData')).extensionsDir, safeExtensionId)
       if (!existsSync(join(extDir, 'setup.py'))) {
-        return { success: false, error: 'No setup.py found for this extension' }
+        return { success: false, error: 'setup.py is missing from the extension folder — the install looks incomplete. Uninstall the extension and install it again.' }
       }
       const { sm: gpuSm, cudaVersion } = await detectGpuInfo()
       await runExtensionSetup(extDir, gpuSm, cudaVersion, (line) => logger.info(`[ext-repair] ${line}`))

--- a/src/areas/models/ModelsPage.tsx
+++ b/src/areas/models/ModelsPage.tsx
@@ -63,6 +63,7 @@ export default function ModelsPage(): JSX.Element {
 
   // Uninstall modal state
   const [uninstallTarget, setUninstallTarget] = useState<string | null>(null)
+  const [uninstallError,  setUninstallError]  = useState<string | null>(null)
   const [modelsToDelete,  setModelsToDelete]  = useState<Set<string>>(new Set())
 
   // Search / filter / sort / detail drawer
@@ -239,7 +240,13 @@ export default function ModelsPage(): JSX.Element {
     for (const modelId of modelsToDelete) {
       await window.electron.model.delete(modelId)
     }
-    await uninstallExt(extId)
+    const result = await uninstallExt(extId)
+    if (!result.success) {
+      // Keep the dialog open so the failure is visible (locked folder, etc.)
+      setUninstallError(result.error ?? 'Could not delete the extension folder.')
+      return
+    }
+    setUninstallError(null)
     setUninstallTarget(null)
     setModelsToDelete(new Set())
     setSelectedId((id) => (id === extId ? null : id))
@@ -635,7 +642,7 @@ export default function ModelsPage(): JSX.Element {
         return createPortal(
           <div
             className="fixed inset-0 z-[9999] flex items-center justify-center"
-            onMouseDown={(e) => { if (e.target === e.currentTarget) { setUninstallTarget(null); setModelsToDelete(new Set()) } }}
+            onMouseDown={(e) => { if (e.target === e.currentTarget) { setUninstallTarget(null); setModelsToDelete(new Set()); setUninstallError(null) } }}
           >
             <div className="absolute inset-0 bg-zinc-950/70 backdrop-blur-sm animate-fade-in" />
             <div className="relative w-96 rounded-2xl bg-zinc-900 border border-accent/20 shadow-2xl shadow-accent/5 overflow-hidden animate-slide-up-center">
@@ -692,9 +699,18 @@ export default function ModelsPage(): JSX.Element {
                   </div>
                 )}
 
+                {uninstallError && (
+                  <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-red-950/30 border border-red-800/30">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-red-400 shrink-0 mt-0.5">
+                      <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+                    </svg>
+                    <p className="text-[11px] text-red-400 break-words">{uninstallError}</p>
+                  </div>
+                )}
+
                 <div className="flex gap-2.5">
                   <button
-                    onClick={() => { setUninstallTarget(null); setModelsToDelete(new Set()) }}
+                    onClick={() => { setUninstallTarget(null); setModelsToDelete(new Set()); setUninstallError(null) }}
                     className="flex-1 py-2.5 rounded-xl bg-zinc-800 hover:bg-zinc-700/80 text-zinc-400 hover:text-zinc-200 text-sm font-medium transition-colors border border-zinc-700/50"
                   >
                     Cancel

--- a/src/areas/models/components/ExtensionDrawer.tsx
+++ b/src/areas/models/components/ExtensionDrawer.tsx
@@ -40,7 +40,16 @@ export function ExtensionDrawer({
   const [syncing,     setSyncing]     = useState(false)
   const [syncError,   setSyncError]   = useState<string | null>(null)
 
-  const isModel = ext.type === 'model'
+  const isModel     = ext.type === 'model'
+  // Built-ins are corrupted-flagged too (builtin-sync repairs them on restart),
+  // but they can't be deleted — show the banner without the delete action.
+  const isCorrupted = !!ext.corrupted
+  const corruptedMsg =
+    ext.manifestError === 'invalid'
+      ? 'This extension folder has a manifest that cannot be parsed. Fix the JSON syntax in its manifest.json, or delete the folder and reinstall.'
+      : ext.manifestError === 'incomplete'
+        ? 'A previous install of this extension never completed. Delete the folder, then install the extension again.'
+        : 'This extension folder is incomplete (its manifest is missing) — usually the leftover of an interrupted install. Delete the folder, then install the extension again.'
   const isLocal = typeof ext.source === 'string' && ext.source.startsWith('local://')
   const localPath = isLocal ? ext.source!.replace('local://', '') : null
   const { total, done, installing, hasAvailable } = extInstallSummary(ext, installedIds, downloading)
@@ -125,6 +134,22 @@ export function ExtensionDrawer({
 
         {/* Body */}
         <div className="flex-1 min-h-0 overflow-y-auto px-5 py-5">
+          {/* Corrupted install */}
+          {isCorrupted && (
+            <div className="mb-5 flex items-start gap-2.5 px-3 py-3 rounded-lg bg-amber-950/30 border border-amber-800/40">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-amber-400 shrink-0 mt-0.5">
+                <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+              <div className="min-w-0">
+                <p className="text-[12px] font-semibold text-amber-400">Corrupted installation</p>
+                <p className="text-[11px] leading-5 text-amber-400/80 mt-1">
+                  {ext.builtin ? 'This built-in extension folder is damaged — restart Modly to let it re-sync.' : corruptedMsg}
+                </p>
+              </div>
+            </div>
+          )}
+
           {/* Error */}
           {error && (
             <div className="mb-5 flex items-start gap-2 px-3 py-2.5 rounded-lg bg-red-950/30 border border-red-800/30">
@@ -242,7 +267,20 @@ export function ExtensionDrawer({
 
         {/* Footer */}
         <div className="px-5 py-4 border-t border-zinc-800/80 flex items-center gap-2.5 shrink-0">
-          {isModel && hasAvailable ? (
+          {isCorrupted && !ext.builtin ? (
+            <button
+              onClick={() => onUninstall(ext.id)}
+              disabled={disabled}
+              className="flex-1 inline-flex items-center justify-center gap-2 px-3.5 py-2.5 rounded-[9px] text-xs font-semibold bg-red-600/90 text-white hover:bg-red-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <polyline points="3 6 5 6 21 6" />
+                <path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6" />
+                <path d="M10 11v6M14 11v6" />
+              </svg>
+              Delete broken folder
+            </button>
+          ) : isModel && hasAvailable ? (
             <button
               onClick={() => onInstallAll(ext)}
               disabled={disabled || installing}
@@ -263,7 +301,7 @@ export function ExtensionDrawer({
             </button>
           )}
 
-          {isModel && (
+          {isModel && !isCorrupted && (
             <button
               onClick={handleRepair}
               disabled={repairing || disabled}
@@ -295,7 +333,7 @@ export function ExtensionDrawer({
             </button>
           )}
 
-          {!ext.builtin && (
+          {!ext.builtin && !isCorrupted && (
             <button
               onClick={() => onUninstall(ext.id)}
               disabled={disabled}

--- a/src/shared/types/electron.d.ts
+++ b/src/shared/types/electron.d.ts
@@ -37,6 +37,10 @@ export interface ModelExtension {
   source?:      string
   localPath?:   string
   nodes:        ExtensionNode[]
+  /** Folder exists but is not a loadable extension — see manifestError */
+  corrupted?:   boolean
+  /** Why the folder is corrupted: manifest gone, manifest unparseable, or install never completed */
+  manifestError?: 'missing' | 'invalid' | 'incomplete'
 }
 
 export interface ParamSchema {
@@ -65,6 +69,10 @@ export interface ProcessExtension {
   localPath?:   string
   entry:        string
   nodes:        ExtensionNode[]
+  /** Folder exists but is not a loadable extension — see manifestError */
+  corrupted?:   boolean
+  /** Why the folder is corrupted: manifest gone, manifest unparseable, or install never completed */
+  manifestError?: 'missing' | 'invalid' | 'incomplete'
 }
 
 export type AnyExtension = ModelExtension | ProcessExtension


### PR DESCRIPTION
## Why

A user hit `No setup.py found for this extension` on hunyuan3d-mini (see the Discord help thread): a failed install could leave a **half-deleted extension folder** behind — the rollback `rm` silently failed on Windows file locks after already deleting `manifest.json`/`setup.py`. The broken folder then showed up as an empty skeleton card with a Repair button that could only fail. Fixes #223 as well.

## What

### Atomic, crash-safe installs
- Install copies into a **unique staging dir** (`.modly-staging-<id>-<ts>`), swaps it into place with retried renames, then runs `setup.py`/`npm install` **in the final folder** under a `.modly-incomplete` marker (venvs record absolute paths — the folder must not move after setup). Setup failure → previous version restored on the spot.
- **Startup reconciler**: purges stale staging dirs; a backup whose extension folder is missing or still marked incomplete is **restored** (last good copy), otherwise discarded. Verified live against all four crash states (kill between renames, kill mid-setup, stale staging, stale backup).
- Shared `fsWithRetry`/`rmWithRetry`/`renameWithRetry` (EBUSY/EPERM/EACCES + progressive backoff) replace the silent `rm` calls; `model:delete` unified on the same helper.

### Broken folders become actionable
- `extensions:list` flags unloadable folders as `corrupted` with a `manifestError` cause (`missing` / `invalid` / `incomplete`); dot-dirs skipped; in-flight installs hidden. The Python registry also skips dot-dirs and marked folders (no more loading a mid-install staging dir on reload).
- Drawer shows a per-cause **Corrupted installation** banner with a **Delete broken folder** action; Repair is hidden when it can't help. `extensions:uninstall` now accepts arbitrary broken folder names (root-confined via `resolvePathWithinRoot`, which now also rejects `''`/`'.'`) and always returns `{success,error}`. ModelsPage surfaces uninstall failures instead of silently closing the dialog.

### Bandwidth (#223)
- `PIP_CACHE_DIR` → `dependencies/pip-cache` for every `setup.py` run, and the setup launcher strips `--no-cache-dir` from pip commands. A retried install reuses the multi-GB torch wheels instead of re-downloading them.

## Testing
- `tsc --noEmit`, `eslint` clean; 23 py + 77 node tests green (new unit tests for staging/backup path helpers and root-escape guards)
- Reconciler exercised live on all four crash states (restore / discard / purge / no-op)
- pip-cache launcher exercised end-to-end with the real embedded Python: `--no-cache-dir` stripped, cache populated, package installed