### PR TITLE
fix(extensions): allow npm lifecycle scripts on install

### DIFF
--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -1161,7 +1161,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
             emit({ step: 'setting_up', message: 'Installing dependencies…' })
             await new Promise<void>((resolve, reject) => {
               const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-              const child = spawn(npm, ['install', '--omit=dev', '--no-audit', '--no-fund'], {
+              const child = spawn(npm, ['install', '--omit=dev', '--no-audit', '--no-fund', '--ignore-scripts=false'], {
                 cwd:   destDir,
                 stdio: 'pipe',
               })

--- a/scripts/build-builtins.mjs
+++ b/scripts/build-builtins.mjs
@@ -43,7 +43,7 @@ for (const id of readdirSync(srcDir)) {
   if (existsSync(pkgSrc)) {
     cpSync(pkgSrc, join(extOutDir, 'package.json'))
     console.log(`[build-builtins] ${id}: Installing npm dependencies…`)
-    execSync('npm install --omit=dev --no-audit --no-fund', {
+    execSync('npm install --omit=dev --no-audit --no-fund --ignore-scripts=false', {
       cwd:   extOutDir,
       stdio: 'inherit',
     })


### PR DESCRIPTION
if user has `ignore-scripts=true` e.g. in their global `.npmrc` file no postinstall scripts are run (for example sharp) which leaves the native binaries missing