### PR TITLE
Rework the Library popover: usable default size, search auto-expand, drag-resizable height

### DIFF
--- a/api/routers/agent.py
+++ b/api/routers/agent.py
@@ -1,11 +1,14 @@
 """
 Agent chat endpoint — runs an Ollama-powered tool-use loop against Modly's API.
 """
+import json
 import re
 import uuid
 import httpx
 from fastapi import APIRouter
 from pydantic import BaseModel
+
+import services.generator_registry as reg_module
 
 router = APIRouter(prefix="/agent", tags=["agent"])
 
@@ -408,6 +411,60 @@ def _extract_thinking(msg: dict) -> tuple[str, str | None]:
     return content, thinking
 
 
+def _read_glb_modly_extras(glb_path) -> dict | None:
+    """Parse a GLB's leading JSON chunk and return asset.extras.modly, if present.
+    Used only as a fallback for assets that predate the .tags.json sidecar."""
+    try:
+        with open(glb_path, "rb") as f:
+            header = f.read(12)
+            if len(header) < 12 or header[0:4] != b"glTF":
+                return None
+            chunk_header = f.read(8)
+            if len(chunk_header) < 8 or chunk_header[4:8] != b"JSON":
+                return None
+            chunk_length = int.from_bytes(chunk_header[0:4], "little")
+            doc = json.loads(f.read(chunk_length))
+            return (doc.get("asset") or {}).get("extras", {}).get("modly")
+    except Exception:
+        return None
+
+
+def _load_asset_meta(workspace_rel_path: str) -> dict | None:
+    """Resolve name/project/tags/lineage for the model currently in the viewer.
+
+    Reads the .tags.json sidecar when present, falling back to the GLB's own
+    embedded extras.modly for name/project/tags. Lineage (derived_from) is only
+    ever written to the sidecar, so an asset with no sidecar has none to report.
+    """
+    workspace_dir = reg_module.WORKSPACE_DIR.resolve()
+    abs_path = (workspace_dir / workspace_rel_path).resolve()
+    if not str(abs_path).startswith(str(workspace_dir)):
+        return None  # escapes the workspace — refuse to read
+
+    sidecar_path = abs_path.with_suffix(".tags.json")
+    if sidecar_path.exists():
+        try:
+            data = json.loads(sidecar_path.read_text(encoding="utf-8"))
+            return {
+                "name": data.get("name"),
+                "project": data.get("project"),
+                "tags": data.get("tags") or [],
+                "derived_from": data.get("derived_from"),
+            }
+        except Exception:
+            pass  # malformed sidecar — fall through to the GLB fallback
+
+    modly = _read_glb_modly_extras(abs_path)
+    if modly:
+        return {
+            "name": modly.get("name"),
+            "project": modly.get("project"),
+            "tags": modly.get("tags") or [],
+            "derived_from": None,
+        }
+    return None
+
+
 @router.get("/models")
 async def list_ollama_models(ollama_url: str = "http://localhost:11434"):
     async with httpx.AsyncClient(timeout=5.0) as client:
@@ -431,6 +488,30 @@ async def agent_chat(request: AgentChatRequest):
             ctx_lines.append(f"Current mesh path: {request.context['currentMeshPath']}")
         if request.context.get("meshTriangles"):
             ctx_lines.append(f"Current mesh triangles: {request.context['meshTriangles']:,}")
+        if request.context.get("currentClipName"):
+            ctx_lines.append(f"Current animation clip: {request.context['currentClipName']}")
+        if request.context.get("availableClips"):
+            ctx_lines.append(f"Available animation clips: {', '.join(request.context['availableClips'])}")
+
+        mesh_path = request.context.get("currentMeshPath")
+        meta = _load_asset_meta(mesh_path) if mesh_path else None
+        if meta:
+            if meta.get("name"):
+                ctx_lines.append(f"Model name: {meta['name']}")
+            if meta.get("project"):
+                ctx_lines.append(f"Project: {meta['project']}")
+            if meta.get("tags"):
+                ctx_lines.append(f"Tags: {', '.join(meta['tags'])}")
+            derived = meta.get("derived_from")
+            if derived:
+                parent = derived.get("parent") or {}
+                root = derived.get("root") or {}
+                parent_label = parent.get("name") or parent.get("path")
+                root_label = root.get("name") or root.get("path")
+                if parent_label == root_label:
+                    ctx_lines.append(f"Derived from: {parent_label}")
+                else:
+                    ctx_lines.append(f"Derived from: {parent_label} (originally: {root_label})")
         if ctx_lines:
             messages.append({
                 "role": "system",

--- a/electron/main/artifact-registry-service.test.ts
+++ b/electron/main/artifact-registry-service.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeWorkspaceAssetPath,
   openWorkspaceAssetLibraryEntry,
   readWorkspaceAssetLibraryEntry,
+  readWorkspaceAssetLibraryThumbnail,
   registerWorkspaceAssetLibraryIpcHandlers,
 } from './artifact-registry-service.ts'
 
@@ -198,6 +199,27 @@ test('fails closed for unsafe, self, missing, and mismatched sourceWorkspacePath
   assert.equal(!mismatched.success && mismatched.error.code, 'not-openable')
 }))
 
+test('reads a sibling .thumb.png for GLB assets and stays silent when one is missing', () => withWorkspace(async (workspaceDir) => {
+  await mkdir(path.join(workspaceDir, 'Exports/props'), { recursive: true })
+  await writeFile(path.join(workspaceDir, 'Exports/props/hero.glb'), 'glb')
+  await writeFile(path.join(workspaceDir, 'Exports/props/hero.thumb.png'), 'fake-png-bytes')
+  await writeFile(path.join(workspaceDir, 'Exports/props/no-thumb.glb'), 'glb')
+  await writeFile(path.join(workspaceDir, 'Exports/static.ply'), 'ply')
+
+  const withThumb = await readWorkspaceAssetLibraryThumbnail({ workspaceDir, workspacePath: 'Exports/props/hero.glb' })
+  assert.equal(withThumb.success, true)
+  assert.equal(withThumb.success && withThumb.dataUrl, `data:image/png;base64,${Buffer.from('fake-png-bytes').toString('base64')}`)
+
+  const withoutThumb = await readWorkspaceAssetLibraryThumbnail({ workspaceDir, workspacePath: 'Exports/props/no-thumb.glb' })
+  assert.equal(withoutThumb.success, false)
+
+  const nonMesh = await readWorkspaceAssetLibraryThumbnail({ workspaceDir, workspacePath: 'Exports/static.ply' })
+  assert.equal(nonMesh.success, false)
+
+  const unsafe = await readWorkspaceAssetLibraryThumbnail({ workspaceDir, workspacePath: '../secret.glb' })
+  assert.equal(unsafe.success, false)
+}))
+
 test('IPC read and open handlers forward sourceWorkspacePath without trusting malformed payloads', async () => {
   const handlers = new Map<string, (event: unknown, payload: unknown) => Promise<unknown>>()
   registerWorkspaceAssetLibraryIpcHandlers({
@@ -224,7 +246,12 @@ test('registers workspace library IPC handlers with structured results', async (
   assert.equal(typeof handlers.get('workspace:library:list'), 'function')
   assert.equal(typeof handlers.get('workspace:library:read'), 'function')
   assert.equal(typeof handlers.get('workspace:library:open'), 'function')
+  assert.equal(typeof handlers.get('workspace:library:thumbnail'), 'function')
   const result = await handlers.get('workspace:library:read')?.({}, { workspacePath: '../escape.glb' })
   assert.equal(typeof (result as { success?: unknown }).success, 'boolean')
   assert.equal((result as { success: boolean, error?: { code: string } }).error?.code, 'unsafe-path')
+  const thumbnail = await handlers.get('workspace:library:thumbnail')?.({}, { workspacePath: '../escape.glb' })
+  assert.equal((thumbnail as { success: boolean }).success, false)
+  const missingPayload = await handlers.get('workspace:library:thumbnail')?.({}, {})
+  assert.equal((missingPayload as { success: boolean }).success, false)
 })

--- a/electron/main/artifact-registry-service.ts
+++ b/electron/main/artifact-registry-service.ts
@@ -12,6 +12,7 @@ import type {
   AssetLibraryPreviewPayload,
   AssetLibraryReadResult,
   AssetLibrarySourceScope,
+  AssetLibraryThumbnailResult,
 } from '../../src/shared/types/assetLibrary'
 import type { ArtifactProvenance } from '../../src/shared/types/artifacts'
 
@@ -49,6 +50,10 @@ export interface WorkspaceAssetLibraryRequest {
 export interface WorkspaceAssetLibraryReadRequest extends WorkspaceAssetLibraryRequest {
   workspacePath: string
   sourceWorkspacePath?: string
+}
+
+export interface WorkspaceAssetLibraryThumbnailRequest extends WorkspaceAssetLibraryRequest {
+  workspacePath: string
 }
 
 interface AssetLibraryMetadata {
@@ -342,6 +347,21 @@ export async function openWorkspaceAssetLibraryEntry(request: WorkspaceAssetLibr
   return { success: true, entry: read.entry }
 }
 
+// Thumbnails are pre-rendered beside their source mesh (see thumbs.py): a
+// `<name>.glb` asset may have a sibling `<name>.thumb.png`. Missing files are
+// a normal, silent condition, never surfaced as an AssetLibraryError.
+export async function readWorkspaceAssetLibraryThumbnail(request: WorkspaceAssetLibraryThumbnailRequest): Promise<AssetLibraryThumbnailResult> {
+  try {
+    const normalized = normalizeWorkspaceAssetPath(request.workspaceDir, request.workspacePath)
+    if (!isGlbOrGltf(normalized.workspacePath)) return { success: false }
+    const thumbnailAbsolutePath = normalized.absolutePath.replace(/\.(glb|gltf)$/i, '.thumb.png')
+    const buffer = await readFile(thumbnailAbsolutePath)
+    return { success: true, dataUrl: `data:image/png;base64,${buffer.toString('base64')}` }
+  } catch {
+    return { success: false }
+  }
+}
+
 function readPayloadRequest(payload: unknown): { workspacePath?: string, sourceWorkspacePath?: string } {
   if (typeof payload !== 'object' || payload === null) return {}
   const values = payload as { workspacePath?: unknown, sourceWorkspacePath?: unknown }
@@ -362,5 +382,10 @@ export function registerWorkspaceAssetLibraryIpcHandlers(deps: WorkspaceAssetLib
     const { workspacePath, sourceWorkspacePath } = readPayloadRequest(payload)
     if (!workspacePath) return { success: false, error: libraryError('invalid-request', 'workspacePath is required.') }
     return openWorkspaceAssetLibraryEntry({ workspaceDir: deps.getWorkspaceDir(), workspacePath, sourceWorkspacePath })
+  })
+  deps.ipcMain.handle('workspace:library:thumbnail', async (_event, payload) => {
+    const { workspacePath } = readPayloadRequest(payload)
+    if (!workspacePath) return { success: false }
+    return readWorkspaceAssetLibraryThumbnail({ workspaceDir: deps.getWorkspaceDir(), workspacePath })
   })
 }

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, shell, session } from 'electron'
 import { join } from 'path'
+import { readFileSync, writeFileSync } from 'fs'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { setupIpcHandlers } from './ipc-handlers'
 import { PythonBridge } from './python-bridge'
@@ -15,6 +16,37 @@ let pythonBridge: PythonBridge | null = null
 // through the uncaughtException handler forever. Swallow stream errors.
 process.stdout?.on('error', () => {})
 process.stderr?.on('error', () => {})
+
+// UI zoom: Ctrl/Cmd with + / - / 0 scales the whole window like a browser,
+// clamped to a sane range and persisted across restarts. This is done at the
+// Chromium level (not CSS) so pointer math in the 3D viewport stays correct.
+const ZOOM_MIN = -2
+const ZOOM_MAX = 4
+
+function zoomFilePath(): string {
+  return join(app.getPath('userData'), 'ui-zoom.json')
+}
+
+function loadZoomLevel(): number {
+  try {
+    const saved = JSON.parse(readFileSync(zoomFilePath(), 'utf-8')) as { level?: number }
+    return typeof saved.level === 'number' ? saved.level : 0
+  } catch {
+    return 0
+  }
+}
+
+function saveZoomLevel(level: number): void {
+  try {
+    writeFileSync(zoomFilePath(), JSON.stringify({ level }), 'utf-8')
+  } catch (err) {
+    logger.error(`Failed to persist UI zoom level: ${err}`)
+  }
+}
+
+function clampZoomLevel(level: number): number {
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, level))
+}
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -57,6 +89,33 @@ function createWindow(): void {
       event.preventDefault()
       app.quit()
     }
+
+    const isZoomChord = input.type === 'keyDown' && (input.control || input.meta) && !input.alt
+    if (!isZoomChord) return
+
+    const wc = mainWindow?.webContents
+    if (!wc) return
+
+    if (input.key === '+' || input.key === '=') {
+      event.preventDefault()
+      const level = clampZoomLevel(wc.getZoomLevel() + 0.5)
+      wc.setZoomLevel(level)
+      saveZoomLevel(level)
+    } else if (input.key === '-' || input.key === '_') {
+      event.preventDefault()
+      const level = clampZoomLevel(wc.getZoomLevel() - 0.5)
+      wc.setZoomLevel(level)
+      saveZoomLevel(level)
+    } else if (input.key === '0') {
+      event.preventDefault()
+      wc.setZoomLevel(0)
+      saveZoomLevel(0)
+    }
+  })
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    const level = loadZoomLevel()
+    if (level) mainWindow?.webContents.setZoomLevel(level)
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -1395,7 +1395,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
   })
 
   // Run a process extension in an isolated worker thread
-  ipcMain.handle('extensions:runProcess', async (_, extensionId: string, input: { filePath?: string; text?: string; texts?: (string | undefined)[]; nodeId?: string }, params: Record<string, unknown>) => {
+  ipcMain.handle('extensions:runProcess', async (_, extensionId: string, input: { filePath?: string; text?: string; texts?: (string | undefined)[]; nodeId?: string; sourceAssetPath?: string }, params: Record<string, unknown>) => {
     const userData        = app.getPath('userData')
     const { extensionsDir, workspaceDir } = getSettings(userData)
 

--- a/electron/main/process-runner.ts
+++ b/electron/main/process-runner.ts
@@ -52,6 +52,9 @@ export interface ProcessInput {
   /** Per-slot texts for multi-text-input nodes (index = target handle slot). */
   texts?:    (string | undefined)[]
   nodeId?:   string
+  /** Absolute path of the existing workspace asset this input was sourced from
+   *  (if any) — threaded through the run so mesh-exporter can record lineage. */
+  sourceAssetPath?: string
 }
 
 export interface ProcessResult {

--- a/electron/preload/artifact-registry-preload.test.ts
+++ b/electron/preload/artifact-registry-preload.test.ts
@@ -24,6 +24,7 @@ test('preload exposes scoped workspace library list/read/open methods', async ()
     workspacePath: 'Workflows/checkpoints/hero.landmarks.v1.json',
     sourceWorkspacePath: 'Workflows/checkpoints/hero.glb',
   })
+  await api.workspace.library.thumbnail({ workspacePath: 'Exports/hero.glb' })
 
   assert.deepEqual(calls, [
     { channel: 'workspace:library:list', payload: undefined },
@@ -41,5 +42,6 @@ test('preload exposes scoped workspace library list/read/open methods', async ()
         sourceWorkspacePath: 'Workflows/checkpoints/hero.glb',
       },
     },
+    { channel: 'workspace:library:thumbnail', payload: { workspacePath: 'Exports/hero.glb' } },
   ])
 })

--- a/electron/preload/electron-api.ts
+++ b/electron/preload/electron-api.ts
@@ -233,7 +233,7 @@ export function createElectronApi(ipcRenderer: IpcRendererLike, webFrame: WebFra
 
       runProcess: (
         extensionId: string,
-        input:       { filePath?: string; text?: string; texts?: (string | undefined)[]; nodeId?: string },
+        input:       { filePath?: string; text?: string; texts?: (string | undefined)[]; nodeId?: string; sourceAssetPath?: string },
         params:      Record<string, unknown>,
       ): Promise<{ success: boolean; result?: { filePath?: string; text?: string }; error?: string }> =>
         ipcRenderer.invoke('extensions:runProcess', extensionId, input, params) as Promise<{ success: boolean; result?: { filePath?: string; text?: string }; error?: string }>,

--- a/electron/preload/electron-api.ts
+++ b/electron/preload/electron-api.ts
@@ -4,6 +4,8 @@ import type {
   AssetLibraryOpenResult,
   AssetLibraryReadRequest,
   AssetLibraryReadResult,
+  AssetLibraryThumbnailRequest,
+  AssetLibraryThumbnailResult,
 } from '../../src/shared/types/assetLibrary'
 
 export interface IpcRendererLike {
@@ -189,6 +191,7 @@ export function createElectronApi(ipcRenderer: IpcRendererLike, webFrame: WebFra
         list: (): Promise<AssetLibraryListResult> => ipcRenderer.invoke('workspace:library:list') as Promise<AssetLibraryListResult>,
         read: (request: AssetLibraryReadRequest): Promise<AssetLibraryReadResult> => ipcRenderer.invoke('workspace:library:read', request) as Promise<AssetLibraryReadResult>,
         open: (request: AssetLibraryOpenRequest): Promise<AssetLibraryOpenResult> => ipcRenderer.invoke('workspace:library:open', request) as Promise<AssetLibraryOpenResult>,
+        thumbnail: (request: AssetLibraryThumbnailRequest): Promise<AssetLibraryThumbnailResult> => ipcRenderer.invoke('workspace:library:thumbnail', request) as Promise<AssetLibraryThumbnailResult>,
       },
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modly",
-  "version": "0.3.5",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modly",
-      "version": "0.3.5",
+      "version": "0.4.1",
       "dependencies": {
         "@electron-toolkit/utils": "^4.0.0",
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
@@ -25,6 +25,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@types/node": "^22.10.1",
         "@types/react": "^18.3.17",
         "@types/react-dom": "^18.3.5",
@@ -37,9 +38,12 @@
         "electron-builder": "^24.13.3",
         "electron-vite": "^2.3.0",
         "eslint": "^9.17.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "globals": "^17.6.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.2",
+        "typescript-eslint": "^8.61.1",
         "vite": "^5.4.0"
       }
     },
@@ -1193,6 +1197,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
@@ -1206,10 +1223,11 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2468,6 +2486,301 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@use-gesture/core": {
@@ -5137,6 +5450,26 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -5163,6 +5496,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
@@ -5716,10 +6062,11 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -5843,6 +6190,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hls.js": {
@@ -8314,6 +8678,19 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8390,6 +8767,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {
@@ -9166,6 +9567,29 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/src/areas/generate/GeneratePage.tsx
+++ b/src/areas/generate/GeneratePage.tsx
@@ -12,12 +12,15 @@ import { resolveAssetLibraryOpenTarget, type ProjectedAssetLibraryEntry } from '
 import {
   ASSET_LIBRARY_SORT_OPTIONS,
   buildAssetLibraryOpenRequest,
+  clampAssetLibraryPanelWidth,
   createAssetLibraryOpenJob,
   describeAssetLibraryOpenability,
   filterAssetLibraryScopeGroups,
   getDefaultAssetLibraryCollapsedSectionKeys,
+  getStoredAssetLibraryPanelWidth,
   isAssetLibraryEntryOpenable,
   resolveOpenPanelAfterLibrarySelection,
+  storeAssetLibraryPanelWidth,
   toggleAssetLibrarySectionKey,
   type AssetLibrarySortMode,
   type GenerateOpenPanel,
@@ -368,6 +371,8 @@ function AssetLibraryPopover({
   searchQuery,
   sortMode,
   collapsedSectionKeys,
+  thumbnails,
+  panelWidth,
   onSelectEntry,
   onSearchQueryChange,
   onSortModeChange,
@@ -375,6 +380,7 @@ function AssetLibraryPopover({
   onOpenSelected,
   onRefresh,
   onClose,
+  onResizeMouseDown,
 }: {
   entries: ProjectedAssetLibraryEntry[]
   selectedEntryId: string | null
@@ -384,6 +390,9 @@ function AssetLibraryPopover({
   searchQuery: string
   sortMode: AssetLibrarySortMode
   collapsedSectionKeys: string[]
+  /** Data URLs keyed by workspacePath, populated lazily as thumbnails load. */
+  thumbnails: Record<string, string>
+  panelWidth: number
   onSelectEntry: (entryId: string) => void
   onSearchQueryChange: (value: string) => void
   onSortModeChange: (value: AssetLibrarySortMode) => void
@@ -391,6 +400,7 @@ function AssetLibraryPopover({
   onOpenSelected: () => void
   onRefresh: () => void
   onClose: () => void
+  onResizeMouseDown: (event: React.MouseEvent) => void
 }) {
   const scopeGroups = filterAssetLibraryScopeGroups(entries, searchQuery, sortMode)
   const visibleEntryIds = new Set(scopeGroups.flatMap((scopeGroup) => scopeGroup.entryGroups.flatMap((group) => group.entries.map((entry) => entry.id))))
@@ -409,7 +419,8 @@ function AssetLibraryPopover({
     <div
       role="dialog"
       aria-label="Workspace library"
-      className="absolute top-full left-0 mt-1 z-50 w-[320px] max-w-[calc(100vw-2rem)] bg-zinc-900 border border-zinc-700/60 rounded-xl p-3 flex flex-col gap-3 shadow-xl"
+      style={{ width: panelWidth }}
+      className="absolute top-full left-0 mt-1 z-50 max-w-[calc(100vw-2rem)] bg-zinc-900 border border-zinc-700/60 rounded-xl p-3 flex flex-col gap-3 shadow-xl"
     >
       <div className="flex items-center justify-between gap-2">
         <div>
@@ -424,6 +435,15 @@ function AssetLibraryPopover({
           Close library
         </button>
       </div>
+
+      {/* Resize handle — drag to widen/narrow the library panel; size is persisted. */}
+      <div
+        onMouseDown={onResizeMouseDown}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize workspace library panel"
+        className="absolute top-0 right-0 bottom-0 w-1.5 cursor-col-resize hover:bg-violet-400/40 active:bg-violet-400/60 transition-colors rounded-r-xl"
+      />
 
       <button
         type="button"
@@ -505,6 +525,7 @@ function AssetLibraryPopover({
                             <div id={capabilityRegionId}>
                               {group.entries.map((entry) => {
                                 const selected = entry.id === selectedEntryId
+                                const thumbnailDataUrl = thumbnails[entry.workspacePath]
                                 return (
                                   <button
                                     key={entry.id}
@@ -513,14 +534,23 @@ function AssetLibraryPopover({
                                     aria-pressed={selected}
                                     aria-label={`Select library asset ${entry.displayName}`}
                                     onClick={() => onSelectEntry(entry.id)}
-                                    className={`w-full text-left px-4 py-2 border-t border-zinc-800 first:border-t-0 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400
+                                    className={`flex w-full items-center gap-3 text-left px-4 py-2 border-t border-zinc-800 first:border-t-0 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400
                                       ${selected ? 'bg-violet-500/10 text-zinc-100' : 'text-zinc-300 hover:bg-zinc-800/80'}`}
                                   >
-                                    <div className="flex items-center justify-between gap-2">
-                                      <span className="text-xs font-medium">{entry.displayName}</span>
-                                      <span className="text-[10px] uppercase tracking-wider text-zinc-500">{entry.capability ?? entry.state.replace(/-/g, ' ')}</span>
+                                    {thumbnailDataUrl && (
+                                      <img
+                                        src={thumbnailDataUrl}
+                                        alt=""
+                                        className="h-20 w-20 shrink-0 rounded-lg border border-zinc-800 bg-zinc-950 object-contain"
+                                      />
+                                    )}
+                                    <div className="min-w-0 flex-1">
+                                      <div className="flex items-center justify-between gap-2">
+                                        <span className="text-xs font-medium">{entry.displayName}</span>
+                                        <span className="text-[10px] uppercase tracking-wider text-zinc-500">{entry.capability ?? entry.state.replace(/-/g, ' ')}</span>
+                                      </div>
+                                      <p className="mt-1 truncate text-[10px] text-zinc-500">{entry.workspacePath}</p>
                                     </div>
-                                    <p className="mt-1 truncate text-[10px] text-zinc-500">{entry.workspacePath}</p>
                                   </button>
                                 )
                               })}
@@ -575,8 +605,11 @@ export default function GeneratePage(): JSX.Element {
   const [librarySearchQuery, setLibrarySearchQuery] = useState('')
   const [librarySortMode, setLibrarySortMode] = useState<AssetLibrarySortMode>('type')
   const [libraryCollapsedSectionKeys, setLibraryCollapsedSectionKeys] = useState<string[]>(() => getDefaultAssetLibraryCollapsedSectionKeys())
+  const [libraryThumbnails, setLibraryThumbnails] = useState<Record<string, string>>({})
+  const [libraryPanelWidth, setLibraryPanelWidth] = useState<number>(() => getStoredAssetLibraryPanelWidth())
   const [gizmoMode, setGizmoMode] = useState<'translate' | 'rotate' | 'scale' | null>(null)
   const dragging = useRef(false)
+  const libraryPanelDragging = useRef(false)
   // Populated by Viewer3D — undoes the latest live gizmo transform, if any.
   const gizmoUndoRef = useRef<(() => boolean) | null>(null)
 
@@ -639,6 +672,11 @@ export default function GeneratePage(): JSX.Element {
     void loadLibraryEntries()
     // eslint-disable-next-line react-hooks/exhaustive-deps -- lazy-load guarded by loaded/loading flags
   }, [openPanel, libraryLoaded, libraryLoading])
+
+  // Persist the library panel's width so a manual resize survives app restarts.
+  useEffect(() => {
+    storeAssetLibraryPanelWidth(libraryPanelWidth)
+  }, [libraryPanelWidth])
 
   async function handleUnloadAll() {
     await window.electron.model.unloadAll()
@@ -710,6 +748,7 @@ export default function GeneratePage(): JSX.Element {
         ? current
         : result.entries.find(isAssetLibraryEntryOpenable)?.id ?? result.entries[0]?.id ?? null)
       setLibraryLoaded(true)
+      void loadLibraryThumbnails(result.entries)
     } catch (err) {
       setLibraryLoaded(false)
       setLibraryEntries([])
@@ -718,6 +757,17 @@ export default function GeneratePage(): JSX.Element {
     } finally {
       setLibraryLoading(false)
     }
+  }
+
+  // Thumbnails are best-effort: only .glb/.gltf entries can have a rendered
+  // .thumb.png, and a missing one is silently skipped rather than surfaced.
+  async function loadLibraryThumbnails(entries: ProjectedAssetLibraryEntry[]) {
+    const candidates = entries.filter((entry) => entry.previewKind === '3d-model')
+    const results = await Promise.all(candidates.map(async (entry) => {
+      const result = await assetLibraryService.thumbnail({ workspacePath: entry.workspacePath })
+      return [entry.workspacePath, result.success ? result.dataUrl : null] as const
+    }))
+    setLibraryThumbnails(Object.fromEntries(results.filter((pair): pair is [string, string] => pair[1] !== null)))
   }
 
   async function handleOpenSelectedLibraryEntry() {
@@ -799,6 +849,23 @@ export default function GeneratePage(): JSX.Element {
     }
     const onMouseUp = () => {
       dragging.current = false
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+    }
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+  }, [])
+
+  const onLibraryPanelResizeMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    libraryPanelDragging.current = true
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!libraryPanelDragging.current) return
+      setLibraryPanelWidth((w) => clampAssetLibraryPanelWidth(w + ev.movementX))
+    }
+    const onMouseUp = () => {
+      libraryPanelDragging.current = false
       window.removeEventListener('mousemove', onMouseMove)
       window.removeEventListener('mouseup', onMouseUp)
     }
@@ -929,6 +996,8 @@ export default function GeneratePage(): JSX.Element {
                 searchQuery={librarySearchQuery}
                 sortMode={librarySortMode}
                 collapsedSectionKeys={libraryCollapsedSectionKeys}
+                thumbnails={libraryThumbnails}
+                panelWidth={libraryPanelWidth}
                 onSelectEntry={(entryId) => {
                   setLibraryError(null)
                   setLibrarySelectedEntryId(entryId)
@@ -939,6 +1008,7 @@ export default function GeneratePage(): JSX.Element {
                 onOpenSelected={() => { void handleOpenSelectedLibraryEntry() }}
                 onRefresh={() => { void loadLibraryEntries() }}
                 onClose={() => setOpenPanel(null)}
+                onResizeMouseDown={onLibraryPanelResizeMouseDown}
               />
             )}
           </div>

--- a/src/areas/generate/GeneratePage.tsx
+++ b/src/areas/generate/GeneratePage.tsx
@@ -27,8 +27,33 @@ import {
 } from './assetLibraryUi'
 
 const MIN_WIDTH = 220
-const MAX_WIDTH = 520
+const MAX_WIDTH = 900
 const DEFAULT_WIDTH = 320
+
+const PANEL_WIDTH_STORAGE_KEY = 'modly-panel-width'
+
+function clampPanelWidth(width: number): number {
+  return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, width))
+}
+
+/** Reads the user's saved Generate panel width, falling back to the default when unset, invalid, or unreadable. */
+function getStoredPanelWidth(): number {
+  try {
+    const raw = Number(localStorage.getItem(PANEL_WIDTH_STORAGE_KEY))
+    return Number.isFinite(raw) && raw > 0 ? clampPanelWidth(raw) : DEFAULT_WIDTH
+  } catch {
+    return DEFAULT_WIDTH
+  }
+}
+
+/** Persists the Generate panel width so it survives app restarts. */
+function storePanelWidth(width: number): void {
+  try {
+    localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(width))
+  } catch {
+    // Ignore quota/private-mode failures — the panel just won't remember its size.
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Export dropdown
@@ -591,7 +616,7 @@ function AssetLibraryPopover({
 
 export default function GeneratePage(): JSX.Element {
   const [unloadStatus, setUnloadStatus] = useState<'idle' | 'done'>('idle')
-  const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH)
+  const [panelWidth, setPanelWidth] = useState<number>(() => getStoredPanelWidth())
   const [openPanel, setOpenPanel] = useState<GenerateOpenPanel>(null)
   const [decimating, setDecimating] = useState(false)
   const [smoothing, setSmoothing] = useState(false)
@@ -677,6 +702,11 @@ export default function GeneratePage(): JSX.Element {
   useEffect(() => {
     storeAssetLibraryPanelWidth(libraryPanelWidth)
   }, [libraryPanelWidth])
+
+  // Persist the generate options panel's width so a manual resize survives app restarts.
+  useEffect(() => {
+    storePanelWidth(panelWidth)
+  }, [panelWidth])
 
   async function handleUnloadAll() {
     await window.electron.model.unloadAll()
@@ -845,7 +875,7 @@ export default function GeneratePage(): JSX.Element {
 
     const onMouseMove = (ev: MouseEvent) => {
       if (!dragging.current) return
-      setPanelWidth((w) => Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, w + ev.movementX)))
+      setPanelWidth((w) => clampPanelWidth(w + ev.movementX))
     }
     const onMouseUp = () => {
       dragging.current = false
@@ -879,10 +909,14 @@ export default function GeneratePage(): JSX.Element {
         <WorkflowPanel />
       </div>
 
-      {/* Resize handle */}
+      {/* Resize handle — drag to widen/narrow the generate options panel; size is persisted. */}
       <div
         onMouseDown={onMouseDown}
-        className="w-1 shrink-0 cursor-col-resize hover:bg-accent/40 active:bg-accent/60 transition-colors"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize the generate options panel"
+        title="Drag to make this panel wider or narrower"
+        className="w-2 shrink-0 cursor-col-resize bg-zinc-600/40 hover:bg-accent/60 active:bg-accent/70 transition-colors"
       />
 
       <div className="flex-1 flex flex-col overflow-hidden">

--- a/src/areas/generate/GeneratePage.tsx
+++ b/src/areas/generate/GeneratePage.tsx
@@ -12,14 +12,18 @@ import { resolveAssetLibraryOpenTarget, type ProjectedAssetLibraryEntry } from '
 import {
   ASSET_LIBRARY_SORT_OPTIONS,
   buildAssetLibraryOpenRequest,
+  clampAssetLibraryPanelHeight,
   clampAssetLibraryPanelWidth,
   createAssetLibraryOpenJob,
   describeAssetLibraryOpenability,
   filterAssetLibraryScopeGroups,
   getDefaultAssetLibraryCollapsedSectionKeys,
+  getStoredAssetLibraryPanelHeight,
   getStoredAssetLibraryPanelWidth,
   isAssetLibraryEntryOpenable,
+  isAssetLibrarySectionExpanded,
   resolveOpenPanelAfterLibrarySelection,
+  storeAssetLibraryPanelHeight,
   storeAssetLibraryPanelWidth,
   toggleAssetLibrarySectionKey,
   type AssetLibrarySortMode,
@@ -398,6 +402,7 @@ function AssetLibraryPopover({
   collapsedSectionKeys,
   thumbnails,
   panelWidth,
+  panelHeight,
   onSelectEntry,
   onSearchQueryChange,
   onSortModeChange,
@@ -406,6 +411,7 @@ function AssetLibraryPopover({
   onRefresh,
   onClose,
   onResizeMouseDown,
+  onResizeHeightMouseDown,
 }: {
   entries: ProjectedAssetLibraryEntry[]
   selectedEntryId: string | null
@@ -418,6 +424,7 @@ function AssetLibraryPopover({
   /** Data URLs keyed by workspacePath, populated lazily as thumbnails load. */
   thumbnails: Record<string, string>
   panelWidth: number
+  panelHeight: number
   onSelectEntry: (entryId: string) => void
   onSearchQueryChange: (value: string) => void
   onSortModeChange: (value: AssetLibrarySortMode) => void
@@ -426,6 +433,7 @@ function AssetLibraryPopover({
   onRefresh: () => void
   onClose: () => void
   onResizeMouseDown: (event: React.MouseEvent) => void
+  onResizeHeightMouseDown: (event: React.MouseEvent) => void
 }) {
   const scopeGroups = filterAssetLibraryScopeGroups(entries, searchQuery, sortMode)
   const visibleEntryIds = new Set(scopeGroups.flatMap((scopeGroup) => scopeGroup.entryGroups.flatMap((group) => group.entries.map((entry) => entry.id))))
@@ -433,6 +441,7 @@ function AssetLibraryPopover({
     ? entries.find((entry) => entry.id === selectedEntryId) ?? null
     : null
   const normalizedSearchQuery = searchQuery.trim()
+  const hasActiveSearch = normalizedSearchQuery.length > 0
   const openDisabled = !selectedEntry || !isAssetLibraryEntryOpenable(selectedEntry) || loading || opening
   const selectedMessage = selectedEntry
     ? describeAssetLibraryOpenability(selectedEntry)
@@ -444,10 +453,10 @@ function AssetLibraryPopover({
     <div
       role="dialog"
       aria-label="Workspace library"
-      style={{ width: panelWidth }}
-      className="absolute top-full left-0 mt-1 z-50 max-w-[calc(100vw-2rem)] bg-zinc-900 border border-zinc-700/60 rounded-xl p-3 flex flex-col gap-3 shadow-xl"
+      style={{ width: panelWidth, height: panelHeight }}
+      className="absolute top-full left-0 mt-1 z-50 max-w-[calc(100vw-2rem)] max-h-[calc(100vh-4rem)] bg-zinc-900 border border-zinc-700/60 rounded-xl p-3 flex flex-col gap-3 shadow-xl overflow-hidden"
     >
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center justify-between gap-2 shrink-0">
         <div>
           <p className="text-[10px] text-zinc-500 uppercase tracking-wider">Workspace library</p>
           <p className="text-xs text-zinc-300">Select a workspace asset and open the supported source in Generate.</p>
@@ -466,20 +475,29 @@ function AssetLibraryPopover({
         onMouseDown={onResizeMouseDown}
         role="separator"
         aria-orientation="vertical"
-        aria-label="Resize workspace library panel"
+        aria-label="Resize workspace library panel width"
         className="absolute top-0 right-0 bottom-0 w-1.5 cursor-col-resize hover:bg-violet-400/40 active:bg-violet-400/60 transition-colors rounded-r-xl"
+      />
+
+      {/* Resize handle — drag to grow/shrink the library panel; size is persisted. */}
+      <div
+        onMouseDown={onResizeHeightMouseDown}
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize workspace library panel height"
+        className="absolute bottom-0 left-0 right-0 h-1.5 cursor-row-resize hover:bg-violet-400/40 active:bg-violet-400/60 transition-colors rounded-b-xl"
       />
 
       <button
         type="button"
         onClick={onRefresh}
         disabled={loading || opening}
-        className="self-start px-2.5 py-1.5 text-[11px] text-zinc-300 bg-zinc-800 hover:bg-zinc-700 disabled:opacity-50 disabled:pointer-events-none rounded-lg transition-colors"
+        className="self-start shrink-0 px-2.5 py-1.5 text-[11px] text-zinc-300 bg-zinc-800 hover:bg-zinc-700 disabled:opacity-50 disabled:pointer-events-none rounded-lg transition-colors"
       >
         Refresh assets
       </button>
 
-      <div className="flex items-end gap-2">
+      <div className="flex items-end gap-2 shrink-0">
         <div className="flex min-w-0 flex-1 flex-col gap-1.5">
           <label htmlFor="asset-library-search" className="text-[11px] text-zinc-300">Search workspace assets</label>
           <input
@@ -488,7 +506,7 @@ function AssetLibraryPopover({
             value={searchQuery}
             onChange={(event) => onSearchQueryChange(event.target.value)}
             placeholder="Search by name, path, scope, or capability"
-            className="bg-zinc-800 border border-zinc-700 rounded-lg px-2.5 py-1.5 text-xs text-zinc-200 w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
+            className="appearance-none bg-zinc-800 border border-zinc-700 rounded-lg px-2.5 py-1.5 text-xs text-zinc-200 w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
           />
         </div>
         <div className="flex w-24 shrink-0 flex-col gap-1.5">
@@ -507,15 +525,15 @@ function AssetLibraryPopover({
       </div>
 
       {loading ? (
-        <p role="status" className="text-xs text-zinc-400">Loading workspace assets…</p>
+        <p role="status" className="flex-1 min-h-0 flex items-center justify-center text-xs text-zinc-400">Loading workspace assets…</p>
       ) : scopeGroups.length === 0 && !normalizedSearchQuery ? (
-        <p role="status" className="text-xs text-zinc-500">No workspace assets are indexed yet.</p>
+        <p role="status" className="flex-1 min-h-0 flex items-center justify-center text-xs text-zinc-500">No workspace assets are indexed yet.</p>
       ) : scopeGroups.length === 0 ? (
-        <p role="status" className="text-xs text-zinc-500">{`No workspace assets match “${normalizedSearchQuery}”.`}</p>
+        <p role="status" className="flex-1 min-h-0 flex items-center justify-center text-center text-xs text-zinc-500">{`No workspace assets match “${normalizedSearchQuery}”.`}</p>
       ) : (
-        <div role="list" aria-label="Workspace library assets" className="max-h-64 overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-950/40">
+        <div role="list" aria-label="Workspace library assets" className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden rounded-lg border border-zinc-800 bg-zinc-950/40">
           {scopeGroups.map((scopeGroup) => {
-            const scopeExpanded = !collapsedSectionKeys.includes(scopeGroup.sectionKey)
+            const scopeExpanded = isAssetLibrarySectionExpanded(collapsedSectionKeys, scopeGroup.sectionKey, hasActiveSearch)
             const scopeRegionId = `asset-library-${scopeGroup.sectionKey.replace(/[^a-z0-9-]+/gi, '-')}`
             return (
               <section key={scopeGroup.sectionKey} role="group" aria-label={`Source scope ${scopeGroup.sourceScopeLabel}`} className="border-b border-zinc-800 last:border-b-0">
@@ -524,7 +542,8 @@ function AssetLibraryPopover({
                   aria-expanded={scopeExpanded}
                   aria-controls={scopeRegionId}
                   onClick={() => onToggleSection(scopeGroup.sectionKey)}
-                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
+                  disabled={hasActiveSearch}
+                  className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 disabled:opacity-50 disabled:pointer-events-none"
                 >
                   <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-300">{scopeGroup.sourceScopeLabel}</span>
                   <span className="text-[10px] text-zinc-500">{scopeExpanded ? 'Hide' : 'Show'}</span>
@@ -532,7 +551,7 @@ function AssetLibraryPopover({
                 {scopeExpanded && (
                   <div id={scopeRegionId}>
                     {scopeGroup.entryGroups.map((group) => {
-                      const capabilityExpanded = !collapsedSectionKeys.includes(group.sectionKey)
+                      const capabilityExpanded = isAssetLibrarySectionExpanded(collapsedSectionKeys, group.sectionKey, hasActiveSearch)
                       const capabilityRegionId = `asset-library-${group.sectionKey.replace(/[^a-z0-9-]+/gi, '-')}`
                       return (
                         <section key={group.sectionKey} role="group" aria-label={`Capability category ${group.capabilityLabel}`} className="border-t border-zinc-800 first:border-t-0">
@@ -541,7 +560,8 @@ function AssetLibraryPopover({
                             aria-expanded={capabilityExpanded}
                             aria-controls={capabilityRegionId}
                             onClick={() => onToggleSection(group.sectionKey)}
-                            className="flex w-full items-center justify-between gap-2 px-4 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
+                            disabled={hasActiveSearch}
+                            className="flex w-full items-center justify-between gap-2 px-4 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 disabled:opacity-50 disabled:pointer-events-none"
                           >
                             <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-400">{group.capabilityLabel}</span>
                             <span className="text-[10px] text-zinc-500">{capabilityExpanded ? 'Hide' : 'Show'}</span>
@@ -559,20 +579,20 @@ function AssetLibraryPopover({
                                     aria-pressed={selected}
                                     aria-label={`Select library asset ${entry.displayName}`}
                                     onClick={() => onSelectEntry(entry.id)}
-                                    className={`flex w-full items-center gap-3 text-left px-4 py-2 border-t border-zinc-800 first:border-t-0 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400
+                                    className={`flex w-full items-center gap-3 text-left px-4 py-1.5 border-t border-zinc-800 first:border-t-0 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400
                                       ${selected ? 'bg-violet-500/10 text-zinc-100' : 'text-zinc-300 hover:bg-zinc-800/80'}`}
                                   >
                                     {thumbnailDataUrl && (
                                       <img
                                         src={thumbnailDataUrl}
                                         alt=""
-                                        className="h-20 w-20 shrink-0 rounded-lg border border-zinc-800 bg-zinc-950 object-contain"
+                                        className="h-10 w-10 shrink-0 rounded-lg border border-zinc-800 bg-zinc-950 object-contain"
                                       />
                                     )}
                                     <div className="min-w-0 flex-1">
                                       <div className="flex items-center justify-between gap-2">
-                                        <span className="text-xs font-medium">{entry.displayName}</span>
-                                        <span className="text-[10px] uppercase tracking-wider text-zinc-500">{entry.capability ?? entry.state.replace(/-/g, ' ')}</span>
+                                        <span className="truncate text-xs font-medium">{entry.displayName}</span>
+                                        <span className="shrink-0 text-[10px] uppercase tracking-wider text-zinc-500">{entry.capability ?? entry.state.replace(/-/g, ' ')}</span>
                                       </div>
                                       <p className="mt-1 truncate text-[10px] text-zinc-500">{entry.workspacePath}</p>
                                     </div>
@@ -592,7 +612,7 @@ function AssetLibraryPopover({
         </div>
       )}
 
-      <div className="rounded-lg border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+      <div className="shrink-0 rounded-lg border border-zinc-800 bg-zinc-950/40 px-3 py-2">
         <p className="text-[11px] text-zinc-400">{selectedMessage}</p>
         {error && <p role="alert" className="mt-2 text-[11px] text-amber-300">{error}</p>}
       </div>
@@ -602,7 +622,7 @@ function AssetLibraryPopover({
         onClick={onOpenSelected}
         disabled={openDisabled}
         aria-label="Open selected asset"
-        className="px-3 py-2 bg-violet-600 hover:bg-violet-500 disabled:bg-zinc-700 disabled:text-zinc-500 text-white text-xs rounded-lg transition-colors font-medium"
+        className="shrink-0 px-3 py-2 bg-violet-600 hover:bg-violet-500 disabled:bg-zinc-700 disabled:text-zinc-500 text-white text-xs rounded-lg transition-colors font-medium"
       >
         {opening ? 'Opening…' : 'Open selected asset'}
       </button>
@@ -632,9 +652,11 @@ export default function GeneratePage(): JSX.Element {
   const [libraryCollapsedSectionKeys, setLibraryCollapsedSectionKeys] = useState<string[]>(() => getDefaultAssetLibraryCollapsedSectionKeys())
   const [libraryThumbnails, setLibraryThumbnails] = useState<Record<string, string>>({})
   const [libraryPanelWidth, setLibraryPanelWidth] = useState<number>(() => getStoredAssetLibraryPanelWidth())
+  const [libraryPanelHeight, setLibraryPanelHeight] = useState<number>(() => getStoredAssetLibraryPanelHeight())
   const [gizmoMode, setGizmoMode] = useState<'translate' | 'rotate' | 'scale' | null>(null)
   const dragging = useRef(false)
   const libraryPanelDragging = useRef(false)
+  const libraryPanelHeightDragging = useRef(false)
   // Populated by Viewer3D — undoes the latest live gizmo transform, if any.
   const gizmoUndoRef = useRef<(() => boolean) | null>(null)
 
@@ -702,6 +724,11 @@ export default function GeneratePage(): JSX.Element {
   useEffect(() => {
     storeAssetLibraryPanelWidth(libraryPanelWidth)
   }, [libraryPanelWidth])
+
+  // Persist the library panel's height so a manual resize survives app restarts.
+  useEffect(() => {
+    storeAssetLibraryPanelHeight(libraryPanelHeight)
+  }, [libraryPanelHeight])
 
   // Persist the generate options panel's width so a manual resize survives app restarts.
   useEffect(() => {
@@ -903,6 +930,23 @@ export default function GeneratePage(): JSX.Element {
     window.addEventListener('mouseup', onMouseUp)
   }, [])
 
+  const onLibraryPanelResizeHeightMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    libraryPanelHeightDragging.current = true
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!libraryPanelHeightDragging.current) return
+      setLibraryPanelHeight((h) => clampAssetLibraryPanelHeight(h + ev.movementY))
+    }
+    const onMouseUp = () => {
+      libraryPanelHeightDragging.current = false
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+    }
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+  }, [])
+
   return (
     <>
       <div className="flex flex-col border-r border-zinc-800 bg-surface-400 overflow-hidden shrink-0" style={{ width: panelWidth }}>
@@ -1032,6 +1076,7 @@ export default function GeneratePage(): JSX.Element {
                 collapsedSectionKeys={libraryCollapsedSectionKeys}
                 thumbnails={libraryThumbnails}
                 panelWidth={libraryPanelWidth}
+                panelHeight={libraryPanelHeight}
                 onSelectEntry={(entryId) => {
                   setLibraryError(null)
                   setLibrarySelectedEntryId(entryId)
@@ -1043,6 +1088,7 @@ export default function GeneratePage(): JSX.Element {
                 onRefresh={() => { void loadLibraryEntries() }}
                 onClose={() => setOpenPanel(null)}
                 onResizeMouseDown={onLibraryPanelResizeMouseDown}
+                onResizeHeightMouseDown={onLibraryPanelResizeHeightMouseDown}
               />
             )}
           </div>

--- a/src/areas/generate/assetLibraryService.test.ts
+++ b/src/areas/generate/assetLibraryService.test.ts
@@ -50,6 +50,7 @@ test('renderer service delegates safe IPC calls and normalizes returned entries'
     }),
     read: async () => ({ success: false, error: { code: 'missing', message: 'Missing' } }),
     open: async (request) => { openRequest = request; return { success: false, error: { code: 'missing', message: 'Missing' } } },
+    thumbnail: async () => ({ success: false }),
   })
 
   const result = await service.list()
@@ -57,4 +58,22 @@ test('renderer service delegates safe IPC calls and normalizes returned entries'
   assert.deepEqual(result.success && result.entries[0]?.warnings, ['a'])
   await service.open({ workspacePath: 'Workflows/hero.landmarks.v1.json', sourceWorkspacePath: 'Workflows/hero.glb' })
   assert.deepEqual(openRequest, { workspacePath: 'Workflows/hero.landmarks.v1.json', sourceWorkspacePath: 'Workflows/hero.glb' })
+})
+
+test('renderer service validates thumbnail requests before IPC and never surfaces an error', async () => {
+  let invoked = false
+  const service = createAssetLibraryService({
+    list: async () => ({ success: true, entries: [] }),
+    read: async () => ({ success: false, error: { code: 'unexpected', message: 'should not run' } }),
+    open: async () => ({ success: false, error: { code: 'unexpected', message: 'should not run' } }),
+    thumbnail: async () => { invoked = true; return { success: true, dataUrl: 'data:image/png;base64,ok' } },
+  })
+
+  const unsafe = await service.thumbnail({ workspacePath: '../escape.glb' })
+  assert.deepEqual(unsafe, { success: false })
+  assert.equal(invoked, false)
+
+  const safe = await service.thumbnail({ workspacePath: 'Exports/hero.glb' })
+  assert.deepEqual(safe, { success: true, dataUrl: 'data:image/png;base64,ok' })
+  assert.equal(invoked, true)
 })

--- a/src/areas/generate/assetLibraryService.ts
+++ b/src/areas/generate/assetLibraryService.ts
@@ -5,6 +5,8 @@ import type {
   AssetLibraryOpenResult,
   AssetLibraryReadRequest,
   AssetLibraryReadResult,
+  AssetLibraryThumbnailRequest,
+  AssetLibraryThumbnailResult,
 } from '../../shared/types/assetLibrary'
 import { projectAssetLibraryEntry, type ProjectedAssetLibraryEntry } from './assetLibraryProjection'
 
@@ -12,6 +14,7 @@ export interface AssetLibraryPreloadApi {
   list: () => Promise<AssetLibraryListResult>
   read: (request: AssetLibraryReadRequest) => Promise<AssetLibraryReadResult>
   open: (request: AssetLibraryOpenRequest) => Promise<AssetLibraryOpenResult>
+  thumbnail: (request: AssetLibraryThumbnailRequest) => Promise<AssetLibraryThumbnailResult>
 }
 
 export type ProjectedAssetLibraryListResult =
@@ -59,6 +62,12 @@ export function createAssetLibraryService(api: AssetLibraryPreloadApi) {
       const result = await api.open(request)
       if (!result.success) return result
       return { success: true, entry: projectAssetLibraryEntry(result.entry) }
+    },
+    // A missing/invalid thumbnail is never an error the UI needs to show — the
+    // Library list just falls back to its text-only row.
+    async thumbnail(request: AssetLibraryThumbnailRequest): Promise<AssetLibraryThumbnailResult> {
+      if (validateWorkspacePath(request.workspacePath)) return { success: false }
+      return api.thumbnail(request)
     },
   }
 }

--- a/src/areas/generate/assetLibraryUi.test.ts
+++ b/src/areas/generate/assetLibraryUi.test.ts
@@ -3,14 +3,18 @@ import test from 'node:test'
 
 import {
   buildAssetLibraryOpenRequest,
+  clampAssetLibraryPanelHeight,
   clampAssetLibraryPanelWidth,
   createAssetLibraryOpenJob,
   describeAssetLibraryOpenability,
   filterAssetLibraryScopeGroups,
   getDefaultAssetLibraryCollapsedSectionKeys,
+  getStoredAssetLibraryPanelHeight,
   getStoredAssetLibraryPanelWidth,
   isAssetLibraryEntryOpenable,
+  isAssetLibrarySectionExpanded,
   resolveOpenPanelAfterLibrarySelection,
+  storeAssetLibraryPanelHeight,
   storeAssetLibraryPanelWidth,
   toggleAssetLibrarySectionKey,
   type AssetLibrarySortMode,
@@ -134,4 +138,30 @@ test('Library panel width clamps to sane bounds and degrades silently without a 
   // node --test has no `localStorage` global — both helpers must fall back rather than throw.
   assert.equal(getStoredAssetLibraryPanelWidth(), 320)
   assert.doesNotThrow(() => storeAssetLibraryPanelWidth(400))
+})
+
+test('Library panel height clamps to sane bounds and degrades silently without a localStorage', () => {
+  assert.equal(clampAssetLibraryPanelHeight(0), 280)
+  assert.equal(clampAssetLibraryPanelHeight(9999), 1000)
+  assert.equal(clampAssetLibraryPanelHeight(500), 500)
+  // node --test has no `localStorage` global — both helpers must fall back rather than throw.
+  assert.equal(getStoredAssetLibraryPanelHeight(), 860)
+  assert.doesNotThrow(() => storeAssetLibraryPanelHeight(500))
+})
+
+test('a live search always shows matched sections, and clearing it falls back to the untouched collapsed-key state', () => {
+  const collapsed = ['scope:workflows', 'capability:workflows:mesh']
+
+  // Nothing typed yet: rendering follows the real collapsed-key list.
+  assert.equal(isAssetLibrarySectionExpanded(collapsed, 'scope:workflows', false), false)
+  assert.equal(isAssetLibrarySectionExpanded(collapsed, 'scope:exports', false), true)
+
+  // A live search forces every visible (already-filtered-to-matches) section open,
+  // regardless of what's actually in collapsedSectionKeys.
+  assert.equal(isAssetLibrarySectionExpanded(collapsed, 'scope:workflows', true), true)
+  assert.equal(isAssetLibrarySectionExpanded(collapsed, 'capability:workflows:mesh', true), true)
+
+  // Clearing the query (hasActiveSearch: false) restores exactly the prior state —
+  // collapsedSectionKeys was never mutated by the search itself.
+  assert.equal(isAssetLibrarySectionExpanded(collapsed, 'scope:workflows', false), false)
 })

--- a/src/areas/generate/assetLibraryUi.test.ts
+++ b/src/areas/generate/assetLibraryUi.test.ts
@@ -3,12 +3,15 @@ import test from 'node:test'
 
 import {
   buildAssetLibraryOpenRequest,
+  clampAssetLibraryPanelWidth,
   createAssetLibraryOpenJob,
   describeAssetLibraryOpenability,
   filterAssetLibraryScopeGroups,
   getDefaultAssetLibraryCollapsedSectionKeys,
+  getStoredAssetLibraryPanelWidth,
   isAssetLibraryEntryOpenable,
   resolveOpenPanelAfterLibrarySelection,
+  storeAssetLibraryPanelWidth,
   toggleAssetLibrarySectionKey,
   type AssetLibrarySortMode,
   type GenerateOpenPanel,
@@ -122,4 +125,13 @@ test('builds linked-source open requests and import jobs for safe sidecars', () 
   const selection = createAssetLibraryOpenJob(sidecar, target, 1718546400001)
   assert.equal(selection?.historyUrl, '/workspace/Workflows/run/hero.glb')
   assert.equal(selection?.job.outputUrl, '/workspace/Workflows/run/hero.glb')
+})
+
+test('Library panel width clamps to sane bounds and degrades silently without a localStorage', () => {
+  assert.equal(clampAssetLibraryPanelWidth(0), 260)
+  assert.equal(clampAssetLibraryPanelWidth(999), 560)
+  assert.equal(clampAssetLibraryPanelWidth(400), 400)
+  // node --test has no `localStorage` global — both helpers must fall back rather than throw.
+  assert.equal(getStoredAssetLibraryPanelWidth(), 320)
+  assert.doesNotThrow(() => storeAssetLibraryPanelWidth(400))
 })

--- a/src/areas/generate/assetLibraryUi.ts
+++ b/src/areas/generate/assetLibraryUi.ts
@@ -68,6 +68,21 @@ export function toggleAssetLibrarySectionKey(currentKeys: string[], sectionKey: 
     : [...currentKeys, sectionKey]
 }
 
+/**
+ * A section renders expanded either because the user left it expanded, or
+ * because a live search matched into it — search always wins so results are
+ * visible without clicking through "Show" first. Clearing the query falls
+ * straight back through to the untouched `collapsedSectionKeys`, so whatever
+ * was collapsed before searching stays collapsed after.
+ */
+export function isAssetLibrarySectionExpanded(
+  collapsedSectionKeys: string[],
+  sectionKey: string,
+  hasActiveSearch: boolean,
+): boolean {
+  return hasActiveSearch || !collapsedSectionKeys.includes(sectionKey)
+}
+
 export function buildAssetLibraryOpenRequest(entry: ProjectedAssetLibraryEntry): AssetLibraryOpenRequest {
   const target = resolveAssetLibraryOpenTarget(entry)
   return target.kind === 'linked-source'
@@ -192,6 +207,35 @@ export function getStoredAssetLibraryPanelWidth(): number {
 export function storeAssetLibraryPanelWidth(width: number): void {
   try {
     localStorage.setItem(ASSET_LIBRARY_PANEL_WIDTH_STORAGE_KEY, String(width))
+  } catch {
+    // Ignore quota/private-mode failures — the panel just won't remember its size.
+  }
+}
+
+export const ASSET_LIBRARY_PANEL_MIN_HEIGHT = 280
+export const ASSET_LIBRARY_PANEL_MAX_HEIGHT = 1000
+export const ASSET_LIBRARY_PANEL_DEFAULT_HEIGHT = 860
+
+const ASSET_LIBRARY_PANEL_HEIGHT_STORAGE_KEY = 'modly-library-panel-height'
+
+export function clampAssetLibraryPanelHeight(height: number): number {
+  return Math.min(ASSET_LIBRARY_PANEL_MAX_HEIGHT, Math.max(ASSET_LIBRARY_PANEL_MIN_HEIGHT, height))
+}
+
+/** Reads the user's saved Library panel height, falling back to the default when unset, invalid, or unreadable. */
+export function getStoredAssetLibraryPanelHeight(): number {
+  try {
+    const raw = Number(localStorage.getItem(ASSET_LIBRARY_PANEL_HEIGHT_STORAGE_KEY))
+    return Number.isFinite(raw) && raw > 0 ? clampAssetLibraryPanelHeight(raw) : ASSET_LIBRARY_PANEL_DEFAULT_HEIGHT
+  } catch {
+    return ASSET_LIBRARY_PANEL_DEFAULT_HEIGHT
+  }
+}
+
+/** Persists the Library panel height so it survives app restarts. */
+export function storeAssetLibraryPanelHeight(height: number): void {
+  try {
+    localStorage.setItem(ASSET_LIBRARY_PANEL_HEIGHT_STORAGE_KEY, String(height))
   } catch {
     // Ignore quota/private-mode failures — the panel just won't remember its size.
   }

--- a/src/areas/generate/assetLibraryUi.ts
+++ b/src/areas/generate/assetLibraryUi.ts
@@ -168,6 +168,35 @@ export function resolveOpenPanelAfterLibrarySelection(currentPanel: GenerateOpen
   return currentPanel === 'library' ? 'library' : currentPanel
 }
 
+export const ASSET_LIBRARY_PANEL_MIN_WIDTH = 260
+export const ASSET_LIBRARY_PANEL_MAX_WIDTH = 560
+export const ASSET_LIBRARY_PANEL_DEFAULT_WIDTH = 320
+
+const ASSET_LIBRARY_PANEL_WIDTH_STORAGE_KEY = 'modly-library-panel-width'
+
+export function clampAssetLibraryPanelWidth(width: number): number {
+  return Math.min(ASSET_LIBRARY_PANEL_MAX_WIDTH, Math.max(ASSET_LIBRARY_PANEL_MIN_WIDTH, width))
+}
+
+/** Reads the user's saved Library panel width, falling back to the default when unset, invalid, or unreadable. */
+export function getStoredAssetLibraryPanelWidth(): number {
+  try {
+    const raw = Number(localStorage.getItem(ASSET_LIBRARY_PANEL_WIDTH_STORAGE_KEY))
+    return Number.isFinite(raw) && raw > 0 ? clampAssetLibraryPanelWidth(raw) : ASSET_LIBRARY_PANEL_DEFAULT_WIDTH
+  } catch {
+    return ASSET_LIBRARY_PANEL_DEFAULT_WIDTH
+  }
+}
+
+/** Persists the Library panel width so it survives app restarts. */
+export function storeAssetLibraryPanelWidth(width: number): void {
+  try {
+    localStorage.setItem(ASSET_LIBRARY_PANEL_WIDTH_STORAGE_KEY, String(width))
+  } catch {
+    // Ignore quota/private-mode failures — the panel just won't remember its size.
+  }
+}
+
 function sortAssetLibraryEntries(
   entries: ProjectedAssetLibraryEntry[],
   sortMode: AssetLibrarySortMode,

--- a/src/areas/generate/components/ChatPanel.tsx
+++ b/src/areas/generate/components/ChatPanel.tsx
@@ -269,6 +269,8 @@ export default function ChatPanel(): JSX.Element {
   const updateCurrentJob = useAppStore((s) => s.updateCurrentJob)
   const pushMeshUrl      = useAppStore((s) => s.pushMeshUrl)
   const undoMesh         = useAppStore((s) => s.undoMesh)
+  const motionClips      = useAppStore((s) => s.motionClips)
+  const activeClipIndex  = useAppStore((s) => s.activeClipIndex)
 
   const workflows     = useWorkflowsStore((s) => s.workflows)
   const saveWorkflow  = useWorkflowsStore((s) => s.save)
@@ -329,6 +331,10 @@ export default function ChatPanel(): JSX.Element {
     const ctx: Record<string, unknown> = {}
     if (currentJob?.outputUrl) ctx.currentMeshPath = currentJob.outputUrl.replace('/workspace/', '')
     if (meshStats?.triangles)  ctx.meshTriangles   = meshStats.triangles
+    if (motionClips.length > 0) {
+      ctx.currentClipName = motionClips[Math.min(activeClipIndex, motionClips.length - 1)]?.name
+      ctx.availableClips  = motionClips.map((c) => c.name)
+    }
     if (workflows.length > 0)  ctx.workflows       = workflows.map((w) => ({ id: w.id, name: w.name }))
     if (allExtensions.length > 0) ctx.extensions   = allExtensions.map((e) => ({
       id: e.id, name: e.name, input: e.input, output: e.output,

--- a/src/areas/generate/components/MotionBar.tsx
+++ b/src/areas/generate/components/MotionBar.tsx
@@ -1,0 +1,48 @@
+export interface MotionClip {
+  name: string
+}
+
+interface MotionBarProps {
+  clips:       MotionClip[]
+  activeIndex: number
+  onChange:    (index: number) => void
+}
+
+function clipLabel(clip: MotionClip, index: number): string {
+  return clip.name || `Motion ${index + 1}`
+}
+
+/** Bottom-left overlay for scrubbing a rigged model's animation clips. */
+export function MotionBar({ clips, activeIndex, onChange }: MotionBarProps): JSX.Element | null {
+  if (clips.length === 0) return null
+
+  if (clips.length === 1) {
+    return (
+      <div className="flex items-center gap-2 bg-zinc-900/70 border border-zinc-700/50 backdrop-blur-sm rounded-xl px-3 py-1.5 pointer-events-none">
+        <span className="text-[10px] text-zinc-500">Playing</span>
+        <span className="text-xs text-zinc-300">{clipLabel(clips[0], 0)}</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 bg-zinc-900/70 border border-zinc-700/50 backdrop-blur-sm rounded-xl px-2 py-1.5">
+      <span className="text-[10px] text-zinc-500 pl-1">Motion</span>
+      <select
+        value={activeIndex}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="bg-zinc-800 text-zinc-200 border border-zinc-700 rounded-md px-2 py-1 text-xs focus:outline-none focus:border-accent/60"
+      >
+        {clips.map((clip, i) => (
+          <option key={i} value={i}>{clipLabel(clip, i)}</option>
+        ))}
+      </select>
+      <button
+        onClick={() => onChange((activeIndex + 1) % clips.length)}
+        className="px-2 py-1 rounded-md text-[11px] font-medium bg-zinc-700 hover:bg-zinc-600 text-zinc-200 transition-colors"
+      >
+        Next
+      </button>
+    </div>
+  )
+}

--- a/src/areas/generate/components/Viewer3D.tsx
+++ b/src/areas/generate/components/Viewer3D.tsx
@@ -2,7 +2,7 @@ import { Component, Suspense, useCallback, useEffect, useMemo, useRef, useState 
 import type { ReactNode, ErrorInfo, MutableRefObject } from 'react'
 import { Canvas, useFrame, useLoader, useThree } from '@react-three/fiber'
 import type { ThreeEvent } from '@react-three/fiber'
-import { Environment, GizmoHelper, Lightformer, OrbitControls, useGizmoContext, useGLTF } from '@react-three/drei'
+import { Environment, GizmoHelper, Html, Lightformer, OrbitControls, useGizmoContext, useGLTF } from '@react-three/drei'
 import { EffectComposer, Outline, Select, Selection } from '@react-three/postprocessing'
 import * as THREE from 'three'
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js'
@@ -151,8 +151,48 @@ function MeshModel({ url, jobId, viewMode, selected, onStats, onSelect, onObject
 }
 
 function GltfMeshModel(props: MeshModelProps): JSX.Element {
-  const { scene } = useGLTF(props.url)
-  return <SceneMeshModel {...props} scene={scene} loaderType="gltf" />
+  const gltf = useGLTF(props.url)
+  const { scene, animations } = gltf
+  const mixerRef = useRef<THREE.AnimationMixer | null>(null)
+  const [clipIndex, setClipIndex] = useState(0)
+
+  // Rigged models arrive with one or more clips; without a mixer they render
+  // frozen in bind pose, which reads as "the rig failed".
+  useEffect(() => {
+    if (!animations?.length) {
+      mixerRef.current = null
+      return
+    }
+    const mixer = new THREE.AnimationMixer(scene)
+    mixer.clipAction(animations[Math.min(clipIndex, animations.length - 1)]).play()
+    mixerRef.current = mixer
+    return () => {
+      mixer.stopAllAction()
+      mixer.uncacheRoot(scene)
+      mixerRef.current = null
+    }
+  }, [scene, animations, clipIndex])
+
+  useFrame((_state, delta) => mixerRef.current?.update(delta))
+
+  return (
+    <>
+      <SceneMeshModel {...props} scene={scene} loaderType="gltf" />
+      {animations && animations.length > 1 && (
+        <Html position={[0, 0, 0]} wrapperClass="clip-picker">
+          <select
+            value={clipIndex}
+            onChange={(e) => setClipIndex(Number(e.target.value))}
+            className="bg-zinc-800 text-zinc-200 border border-zinc-700 rounded px-2 py-1 text-xs"
+          >
+            {animations.map((clip, i) => (
+              <option key={clip.name || i} value={i}>{clip.name || }</option>
+            ))}
+          </select>
+        </Html>
+      )}
+    </>
+  )
 }
 
 function ObjMeshModel(props: MeshModelProps): JSX.Element {

--- a/src/areas/generate/components/Viewer3D.tsx
+++ b/src/areas/generate/components/Viewer3D.tsx
@@ -2,7 +2,7 @@ import { Component, Suspense, useCallback, useEffect, useMemo, useRef, useState 
 import type { ReactNode, ErrorInfo, MutableRefObject } from 'react'
 import { Canvas, useFrame, useLoader, useThree } from '@react-three/fiber'
 import type { ThreeEvent } from '@react-three/fiber'
-import { Environment, GizmoHelper, Html, Lightformer, OrbitControls, useGizmoContext, useGLTF } from '@react-three/drei'
+import { Environment, GizmoHelper, Lightformer, OrbitControls, useGizmoContext, useGLTF } from '@react-three/drei'
 import { EffectComposer, Outline, Select, Selection } from '@react-three/postprocessing'
 import * as THREE from 'three'
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js'
@@ -16,6 +16,7 @@ import SplatViewer, { type SplatViewerHandle } from './SplatViewer'
 import { useGeneration } from '@shared/hooks/useGeneration'
 import { useAppStore } from '@shared/stores/appStore'
 import { ViewerToolbar, type ViewMode } from './ViewerToolbar'
+import { MotionBar, type MotionClip } from './MotionBar'
 import type { LightSettings } from '@shared/stores/appStore'
 import { DEFAULT_LIGHT_SETTINGS } from '@shared/stores/appStore'
 
@@ -142,57 +143,68 @@ interface MeshModelProps {
   onStats: (stats: { vertices: number; triangles: number }) => void
   onSelect: () => void
   onObject: (obj: THREE.Object3D | null) => void
+  onClips: (clips: MotionClip[]) => void
+  clipIndex: number
 }
 
-function MeshModel({ url, jobId, viewMode, selected, onStats, onSelect, onObject }: MeshModelProps): JSX.Element {
+function MeshModel({ url, jobId, viewMode, selected, onStats, onSelect, onObject, onClips, clipIndex }: MeshModelProps): JSX.Element {
   const extension = url.split('?')[0]?.split('.').pop()?.toLowerCase()
-  const common = { url, jobId, viewMode, selected, onStats, onSelect, onObject }
+  const common = { url, jobId, viewMode, selected, onStats, onSelect, onObject, onClips, clipIndex }
   return extension === 'obj' ? <ObjMeshModel {...common} /> : <GltfMeshModel {...common} />
 }
 
 function GltfMeshModel(props: MeshModelProps): JSX.Element {
   const gltf = useGLTF(props.url)
   const { scene, animations } = gltf
-  const mixerRef = useRef<THREE.AnimationMixer | null>(null)
-  const [clipIndex, setClipIndex] = useState(0)
+  const mixerRef  = useRef<THREE.AnimationMixer | null>(null)
+  const actionRef = useRef<THREE.AnimationAction | null>(null)
+  const { onClips, clipIndex } = props
 
   // Rigged models arrive with one or more clips; without a mixer they render
-  // frozen in bind pose, which reads as "the rig failed".
+  // frozen in bind pose, which reads as "the rig failed". The mixer lives for
+  // as long as this model does — clip switches below reuse it.
   useEffect(() => {
     if (!animations?.length) {
       mixerRef.current = null
+      actionRef.current = null
       return
     }
     const mixer = new THREE.AnimationMixer(scene)
-    mixer.clipAction(animations[Math.min(clipIndex, animations.length - 1)]).play()
     mixerRef.current = mixer
     return () => {
       mixer.stopAllAction()
       mixer.uncacheRoot(scene)
       mixerRef.current = null
+      actionRef.current = null
     }
-  }, [scene, animations, clipIndex])
+  }, [scene, animations])
+
+  // Tell the viewer which clips are available so it can render the motion bar.
+  useEffect(() => {
+    onClips(animations?.map((clip) => ({ name: clip.name })) ?? [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onClips is a stable callback
+  }, [animations])
+
+  // Switch to the selected clip, cross-fading so playback never hard-cuts.
+  useEffect(() => {
+    const mixer = mixerRef.current
+    if (!mixer || !animations?.length) return
+    const clip = animations[Math.min(clipIndex, animations.length - 1)]
+    const next = mixer.clipAction(clip)
+    next.reset().setLoop(THREE.LoopRepeat, Infinity)
+    const prev = actionRef.current
+    if (prev && prev !== next) {
+      prev.fadeOut(0.25)
+      next.fadeIn(0.25).play()
+    } else {
+      next.play()
+    }
+    actionRef.current = next
+  }, [animations, clipIndex])
 
   useFrame((_state, delta) => mixerRef.current?.update(delta))
 
-  return (
-    <>
-      <SceneMeshModel {...props} scene={scene} loaderType="gltf" />
-      {animations && animations.length > 1 && (
-        <Html position={[0, 0, 0]} wrapperClass="clip-picker">
-          <select
-            value={clipIndex}
-            onChange={(e) => setClipIndex(Number(e.target.value))}
-            className="bg-zinc-800 text-zinc-200 border border-zinc-700 rounded px-2 py-1 text-xs"
-          >
-            {animations.map((clip, i) => (
-              <option key={clip.name || i} value={i}>{clip.name || }</option>
-            ))}
-          </select>
-        </Html>
-      )}
-    </>
-  )
+  return <SceneMeshModel {...props} scene={scene} loaderType="gltf" />
 }
 
 function ObjMeshModel(props: MeshModelProps): JSX.Element {
@@ -855,6 +867,8 @@ export default function Viewer3D({ lightSettings = DEFAULT_LIGHT_SETTINGS, gizmo
 
   const [viewMode, setViewMode] = useState<ViewMode>('solid')
   const [autoRotate, setAutoRotate] = useState(false)
+  const [clips, setClips] = useState<MotionClip[]>([])
+  const [activeClipIndex, setActiveClipIndex] = useState(0)
   const selected = useAppStore((s) => s.meshSelected)
   const setSelected = useAppStore((s) => s.setMeshSelected)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
@@ -888,6 +902,8 @@ export default function Viewer3D({ lightSettings = DEFAULT_LIGHT_SETTINGS, gizmo
     setSelected(false)
     setViewMode('solid')
     setStoreMeshStats(null)
+    setClips([])
+    setActiveClipIndex(0)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- reset only when the model changes; setters are stable
   }, [modelUrl])
 
@@ -1037,6 +1053,8 @@ export default function Viewer3D({ lightSettings = DEFAULT_LIGHT_SETTINGS, gizmo
                   onStats={setStoreMeshStats}
                   onSelect={() => setSelected(true)}
                   onObject={setMeshObject}
+                  onClips={setClips}
+                  clipIndex={activeClipIndex}
                 />
               </Suspense>
             </Selection>
@@ -1083,12 +1101,15 @@ export default function Viewer3D({ lightSettings = DEFAULT_LIGHT_SETTINGS, gizmo
           />
         )}
 
-        {/* Bottom-left stats overlay */}
-        {meshStats && (
-          <div className="absolute bottom-4 left-4 pointer-events-none">
-            <p className="text-xs text-zinc-500">
-              {meshStats.triangles.toLocaleString()} tri &bull; {meshStats.vertices.toLocaleString()} verts
-            </p>
+        {/* Bottom-left overlays — mesh stats and the motion bar */}
+        {(meshStats || clips.length > 0) && (
+          <div className="absolute bottom-4 left-4 flex flex-col items-start gap-2">
+            {meshStats && (
+              <p className="text-xs text-zinc-500 pointer-events-none">
+                {meshStats.triangles.toLocaleString()} tri &bull; {meshStats.vertices.toLocaleString()} verts
+              </p>
+            )}
+            <MotionBar clips={clips} activeIndex={activeClipIndex} onChange={setActiveClipIndex} />
           </div>
         )}
 

--- a/src/areas/generate/components/Viewer3D.tsx
+++ b/src/areas/generate/components/Viewer3D.tsx
@@ -867,8 +867,21 @@ export default function Viewer3D({ lightSettings = DEFAULT_LIGHT_SETTINGS, gizmo
 
   const [viewMode, setViewMode] = useState<ViewMode>('solid')
   const [autoRotate, setAutoRotate] = useState(false)
-  const [clips, setClips] = useState<MotionClip[]>([])
-  const [activeClipIndex, setActiveClipIndex] = useState(0)
+  const [clips, setClipsState] = useState<MotionClip[]>([])
+  const [activeClipIndex, setActiveClipIndexState] = useState(0)
+  const setStoreMotionClips = useAppStore((s) => s.setMotionClips)
+  const setStoreActiveClipIndex = useAppStore((s) => s.setActiveClipIndex)
+  // Mirror into appStore alongside the local state that actually drives
+  // playback, so sibling panels (e.g. ChatPanel) can read the current clip
+  // without this component handing over playback control.
+  const setClips = useCallback((c: MotionClip[]) => {
+    setClipsState(c)
+    setStoreMotionClips(c)
+  }, [setStoreMotionClips])
+  const setActiveClipIndex = useCallback((i: number) => {
+    setActiveClipIndexState(i)
+    setStoreActiveClipIndex(i)
+  }, [setStoreActiveClipIndex])
   const selected = useAppStore((s) => s.meshSelected)
   const setSelected = useAppStore((s) => s.setMeshSelected)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)

--- a/src/areas/generate/components/WorkflowPanel.tsx
+++ b/src/areas/generate/components/WorkflowPanel.tsx
@@ -160,6 +160,17 @@ function ParamField({ param, value, onChange }: {
   value:    number | string
   onChange: (v: number | string) => void
 }) {
+  if (param.multiline) {
+    return (
+      <textarea
+        value={value as string}
+        placeholder={param.tooltip ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+        rows={5}
+        className={`${inputCls} resize-y min-h-[6rem] leading-relaxed`}
+      />
+    )
+  }
   if (param.type === 'select') {
     return (
       <select value={value} onChange={(e) => onChange(e.target.value)} className={inputCls}>

--- a/src/areas/generate/components/WorkflowPanel.tsx
+++ b/src/areas/generate/components/WorkflowPanel.tsx
@@ -59,6 +59,50 @@ function mimeFromPath(p: string): string {
   return 'image/png'
 }
 
+// ─── Tag suggestions ──────────────────────────────────────────────────────────
+
+const TAG_STOPWORDS = new Set([
+  'a', 'an', 'the', 'of', 'for', 'and', 'or', 'to', 'in', 'on', 'my', 'this', 'is', 'with',
+])
+
+const FIXED_TAG_VOCAB = [
+  'prop', 'character', 'creature', 'environment', 'weapon',
+  'furniture', 'hero-asset', 'background', 'low-poly', 'stylized', 'realistic',
+]
+
+const MAX_TAG_SUGGESTIONS = 10
+
+/** Slugified words pulled from the typed name/project, plus a small fixed vocabulary — capped and deduped. */
+function suggestedTags(modelName: string, project: string): string[] {
+  const fromFields = `${modelName} ${project}`
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((word) => word.length > 1 && !TAG_STOPWORDS.has(word))
+
+  const seen = new Set<string>()
+  const suggestions: string[] = []
+  for (const tag of [...fromFields, ...FIXED_TAG_VOCAB]) {
+    if (!tag || seen.has(tag)) continue
+    seen.add(tag)
+    suggestions.push(tag)
+    if (suggestions.length >= MAX_TAG_SUGGESTIONS) break
+  }
+  return suggestions
+}
+
+function parseTags(value: string): string[] {
+  return value.split(',').map((s) => s.trim()).filter(Boolean)
+}
+
+/** Appends a tag to the comma-separated value, or removes it if already present. */
+function toggleTag(value: string, tag: string): string {
+  const tags = parseTags(value)
+  const i = tags.indexOf(tag)
+  if (i >= 0) tags.splice(i, 1)
+  else tags.push(tag)
+  return tags.join(', ')
+}
+
 // ─── Param field ──────────────────────────────────────────────────────────────
 
 const inputCls = 'w-full bg-zinc-800 border border-zinc-700/80 rounded-md px-2 py-1 text-[11px] text-zinc-200 focus:outline-none focus:border-accent/60'
@@ -141,11 +185,48 @@ function ParamField({ param, value, onChange }: {
       </div>
     )
   }
+  if (param.type === 'text') {
+    return (
+      <input type="text" value={value as string} placeholder={param.tooltip ?? ''}
+        onChange={(e) => onChange(e.target.value)} className={inputCls} />
+    )
+  }
   if (param.type === 'float') {
     return <FloatInput value={value as number} onChange={(v) => onChange(v)} className={inputCls} />
   }
   // int
   return <IntInput value={value as number} onChange={(v) => onChange(v)} className={inputCls} />
+}
+
+function TagSuggestionPills({ value, onChange, modelName, project }: {
+  value:     string
+  onChange:  (v: string) => void
+  modelName: string
+  project:   string
+}) {
+  const suggestions = useMemo(() => suggestedTags(modelName, project), [modelName, project])
+  if (suggestions.length === 0) return null
+
+  const active = new Set(parseTags(value))
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {suggestions.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          onClick={() => onChange(toggleTag(value, tag))}
+          className={`px-2 py-0.5 rounded-full text-[10px] border transition-colors ${
+            active.has(tag)
+              ? 'bg-accent/20 border-accent/60 text-accent-light'
+              : 'bg-zinc-800 border-zinc-700 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200'
+          }`}
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  )
 }
 
 // ─── Workflow dropdown ────────────────────────────────────────────────────────
@@ -226,7 +307,7 @@ function ImageParamRow({ nodeId, nodes, onPatch }: { nodeId: string; nodes: Flow
           <rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/>
           <polyline points="21 15 16 10 5 21"/>
         </svg>
-        <span className="text-[11px] font-medium text-zinc-300">Image</span>
+        <span className="text-[11px] font-medium text-zinc-300">Your sketch or photo — required</span>
       </div>
       {preview ? (
         <button onClick={browse} className="relative w-full aspect-square rounded-lg overflow-hidden border border-zinc-700 group">
@@ -323,13 +404,13 @@ function TextParamRow({ nodeId, nodes, onPatch }: { nodeId: string; nodes: FlowN
         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" strokeWidth="2">
           <path d="M17 6.1H3M21 12.1H3M15.1 18H3"/>
         </svg>
-        <span className="text-[11px] font-medium text-zinc-300">Text</span>
+        <span className="text-[11px] font-medium text-zinc-300">Extra details — optional</span>
       </div>
       <textarea
         value={text}
         onChange={(e) => onPatch(nodeId, { params: { ...(data?.params ?? {}), text: e.target.value } })}
-        placeholder="Enter text…" rows={3}
-        className="w-full bg-zinc-800 border border-zinc-700/80 rounded-md px-2.5 py-2 text-[11px] text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-amber-500/40 resize-none leading-relaxed"
+        placeholder="Enter text…" rows={14}
+        className="w-full bg-zinc-800 border border-zinc-700/80 rounded-md px-2.5 py-2 text-[11px] text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-amber-500/40 resize-y min-h-[14rem] leading-relaxed"
       />
     </div>
   )
@@ -424,13 +505,24 @@ function ExtensionParamRow({ nodeId, ext, nodes, onPatch }: { nodeId: string; ex
         <div className="mt-2 flex flex-col gap-2">
           {ext.params.map((param) => {
             const val = ((data?.params[param.id] ?? param.default) as number | string)
+            const setValue = (v: number | string) =>
+              onPatch(nodeId, { params: { ...(data?.params ?? {}), [param.id]: v } })
             return (
-              <div key={param.id} className="flex items-center gap-2">
-                <label className="text-[10px] text-zinc-500 w-20 shrink-0 truncate">{param.label}</label>
-                <div className="flex-1">
-                  <ParamField param={param} value={val}
-                    onChange={(v) => onPatch(nodeId, { params: { ...(data?.params ?? {}), [param.id]: v } })} />
+              <div key={param.id} className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-2">
+                  <label className="text-[10px] text-zinc-500 w-32 shrink-0 leading-tight">{param.label}</label>
+                  <div className="flex-1">
+                    <ParamField param={param} value={val} onChange={setValue} />
+                  </div>
                 </div>
+                {param.id === 'tags' && (
+                  <TagSuggestionPills
+                    value={String(val)}
+                    onChange={setValue}
+                    modelName={String(data?.params['model_name'] ?? '')}
+                    project={String(data?.params['project'] ?? '')}
+                  />
+                )}
               </div>
             )
           })}

--- a/src/areas/workflows/nodes/mesh-exporter/manifest.json
+++ b/src/areas/workflows/nodes/mesh-exporter/manifest.json
@@ -14,6 +14,27 @@
       "output": "mesh",
       "params_schema": [
         {
+          "id": "model_name",
+          "label": "Name this model (optional)",
+          "type": "text",
+          "default": "",
+          "description": "Used for the file name, e.g. 'brass floor lamp' becomes brass-floor-lamp-4f2a.glb. Leave it blank for a dated name."
+        },
+        {
+          "id": "project",
+          "label": "Which game or project is this for? (optional)",
+          "type": "text",
+          "default": "",
+          "description": "Files are filed under a folder of this name, so the Library groups a game's models together instead of one long list."
+        },
+        {
+          "id": "tags",
+          "label": "Tags (optional, comma separated)",
+          "type": "text",
+          "default": "",
+          "description": "Saved with the model. The exporter adds what it can tell on its own — rigged, animated, textured, how heavy it is."
+        },
+        {
           "id": "export_format",
           "label": "Export Format",
           "type": "select",

--- a/src/areas/workflows/nodes/mesh-exporter/processor.ts
+++ b/src/areas/workflows/nodes/mesh-exporter/processor.ts
@@ -1,13 +1,89 @@
 import path = require('path')
 import fs   = require('fs')
 
-interface ProcessInput  { filePath?: string; text?: string }
+interface ProcessInput  { filePath?: string; text?: string; sourceAssetPath?: string }
 interface ProcessResult { filePath?: string; text?: string }
 interface ProcessContext {
   workspaceDir: string
   tempDir:      string
   log:          (msg: string) => void
   progress:     (pct: number, label: string) => void
+}
+
+// ─── Lineage ──────────────────────────────────────────────────────────────────
+// When the input mesh traces back to an existing workspace asset, record where
+// it came from: the immediate parent, plus the root of the chain (so re-exporting
+// an already-derived model doesn't grow an unbounded ancestry list).
+
+interface DerivedRef  { path: string; name: string | null }
+interface DerivedFrom { parent: DerivedRef; root: DerivedRef }
+
+function sidecarPathFor(assetPath: string): string {
+  return assetPath.replace(/\.[^./\\]+$/, '') + '.tags.json'
+}
+
+/** Workspace-relative form of an absolute path, or null if it's outside the workspace. */
+function toWorkspaceRelative(workspaceDir: string, absPath: string): string | null {
+  const norm   = absPath.replace(/\\/g, '/')
+  const wsNorm = workspaceDir.replace(/\\/g, '/').replace(/\/+$/, '')
+  if (norm !== wsNorm && !norm.startsWith(wsNorm + '/')) return null
+  return norm.slice(wsNorm.length + 1)
+}
+
+/** Reads asset.extras.modly straight out of a GLB's leading JSON chunk — used only
+ *  as a name fallback when a source asset predates the .tags.json sidecar. */
+function readGlbModlyExtras(glbPath: string): { name?: string } | null {
+  try {
+    const fd = fs.openSync(glbPath, 'r')
+    try {
+      const header = Buffer.alloc(12)
+      fs.readSync(fd, header, 0, 12, 0)
+      if (header.toString('ascii', 0, 4) !== 'glTF') return null
+      const chunkHeader = Buffer.alloc(8)
+      fs.readSync(fd, chunkHeader, 0, 8, 12)
+      const chunkLength = chunkHeader.readUInt32LE(0)
+      if (chunkHeader.toString('ascii', 4, 8) !== 'JSON') return null
+      const chunkData = Buffer.alloc(chunkLength)
+      fs.readSync(fd, chunkData, 0, chunkLength, 20)
+      const json = JSON.parse(chunkData.toString('utf-8'))
+      return json?.asset?.extras?.modly ?? null
+    } finally {
+      fs.closeSync(fd)
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolves the `derived_from` sidecar field for an export whose input traces
+ * back to `sourceAssetPath`. Returns null when there's nothing to record (no
+ * source, or the source isn't a workspace asset).
+ */
+function resolveDerivedFrom(sourceAssetPath: string | undefined, workspaceDir: string): DerivedFrom | null {
+  if (!sourceAssetPath) return null
+  const relPath = toWorkspaceRelative(workspaceDir, sourceAssetPath)
+  if (!relPath) return null
+
+  let name: string | null = null
+  let upstream: DerivedFrom | undefined
+
+  const sidecarPath = sidecarPathFor(sourceAssetPath)
+  if (fs.existsSync(sidecarPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(sidecarPath, 'utf-8'))
+      name = data.name ?? null
+      if (data.derived_from) upstream = data.derived_from as DerivedFrom
+    } catch {
+      // Malformed sidecar — treat the source as untagged rather than failing the export.
+    }
+  } else {
+    name = readGlbModlyExtras(sourceAssetPath)?.name ?? null
+  }
+
+  const parent: DerivedRef = { path: relPath, name }
+  const root = upstream?.root ?? parent
+  return { parent, root }
 }
 
 // ─── Geometry extraction ──────────────────────────────────────────────────────
@@ -252,11 +328,16 @@ const processor = async (
   }
   const tags = Array.from(new Set([...typedTags, ...suggested]))
 
+  // Lineage: only recorded when the input actually traces back to an existing
+  // workspace asset — a fresh generation has nothing to chain to.
+  const derivedFrom = resolveDerivedFrom(input.sourceAssetPath, context.workspaceDir)
+
   fs.mkdirSync(path.dirname(outPath), { recursive: true })
   fs.writeFileSync(outPath.replace(/\.[^.]+$/, '') + '.tags.json', JSON.stringify({
     name:    typed || null,
     project: params['project'] || null,
     tags,
+    ...(derivedFrom ? { derived_from: derivedFrom } : {}),
     created: new Date().toISOString(),
   }, null, 2))
 

--- a/src/areas/workflows/nodes/mesh-exporter/processor.ts
+++ b/src/areas/workflows/nodes/mesh-exporter/processor.ts
@@ -200,16 +200,74 @@ const processor = async (
   context.progress(20, 'Loading mesh…')
   const doc = await io.read(input.filePath)
 
-  let outPath: string
-  if (outputPath) {
-    fs.mkdirSync(outputPath, { recursive: true })
-    outPath = path.join(outputPath, `export-${Date.now()}${ext}`)
-  } else {
-    const exportsDir = path.join(context.workspaceDir, 'Exports')
-    fs.mkdirSync(exportsDir, { recursive: true })
-    outPath = path.join(exportsDir, `export-${Date.now()}${ext}`)
+  // modly-friendly-names: a folder of export-1785194887022.glb tells you nothing.
+  const stamp  = new Date()
+  const pad    = (n: number): string => String(n).padStart(2, '0')
+  const unique = Date.now().toString(36).slice(-4)
+  const typed  = String(params['model_name'] ?? '').trim()
+  const slug   = typed
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+  const dated = `model-${stamp.getFullYear()}-${pad(stamp.getMonth() + 1)}-${pad(stamp.getDate())}`
+    + `-${pad(stamp.getHours())}${pad(stamp.getMinutes())}`
+  const baseName = `${slug || dated}-${unique}${ext}`
+
+  const slugify = (s: unknown): string => String(s ?? '').toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40)
+  const project = slugify(params['project'])
+
+  const root = outputPath || path.join(context.workspaceDir, 'Exports')
+  const dir  = project ? path.join(root, project) : root
+  fs.mkdirSync(dir, { recursive: true })
+  const outPath = path.join(dir, baseName)
+
+  // Tags: what the operator typed, plus what the file itself can tell us.
+  const typedTags = String(params['tags'] ?? '').split(',').map(slugify).filter(Boolean)
+  const suggested: string[] = []
+  try {
+    const r = doc.getRoot()
+    if (r.listSkins().length) suggested.push('rigged')
+    if (r.listAnimations().length) {
+      suggested.push('animated')
+      for (const a of r.listAnimations()) {
+        const n = slugify(a.getName())
+        if (n) suggested.push(`clip-${n}`)
+      }
+    }
+    if (r.listTextures().length) suggested.push('textured')
+    let tris = 0
+    for (const m of r.listMeshes())
+      for (const prim of m.listPrimitives()) {
+        const idx = prim.getIndices()
+        tris += idx ? idx.getCount() / 3
+                    : (prim.getAttribute('POSITION')?.getCount() ?? 0) / 3
+      }
+    tris = Math.round(tris)
+    suggested.push(tris < 5000 ? 'low-poly' : tris > 100000 ? 'high-poly' : 'mid-poly')
+    if (project) suggested.push(project)
+  } catch (e) {
+    context.log(`tagging skipped: ${e}`)
   }
+  const tags = Array.from(new Set([...typedTags, ...suggested]))
+
   fs.mkdirSync(path.dirname(outPath), { recursive: true })
+  fs.writeFileSync(outPath.replace(/\.[^.]+$/, '') + '.tags.json', JSON.stringify({
+    name:    typed || null,
+    project: params['project'] || null,
+    tags,
+    created: new Date().toISOString(),
+  }, null, 2))
+
+  try {
+    const asset = doc.getRoot().getAsset()
+    asset.extras = Object.assign({}, asset.extras, {
+      modly: { name: typed || null, project: params['project'] || null, tags },
+    })
+  } catch (e) {
+    context.log(`could not embed tags: ${e}`)
+  }
 
   context.progress(50, `Exporting as ${format.toUpperCase()}…`)
 

--- a/src/areas/workflows/workflowRunStore.ts
+++ b/src/areas/workflows/workflowRunStore.ts
@@ -44,7 +44,15 @@ function flushResume(): void {
   if (fn) fn()
 }
 
-interface NodeOutput { filePath?: string; text?: string; outputType?: string }
+interface NodeOutput {
+  filePath?: string
+  text?:     string
+  outputType?: string
+  /** Absolute path of the existing workspace asset this output traces back to
+   *  (if any) — propagated unchanged from whatever node first resolved it, so a
+   *  mesh-exporter several hops downstream can still record lineage. */
+  sourceAssetPath?: string
+}
 
 function isSceneMeshOutput(output: NodeOutput | undefined): output is NodeOutput & { filePath: string } {
   return output?.outputType === 'mesh' && typeof output.filePath === 'string'
@@ -308,6 +316,11 @@ async function executeExtensionNode(
   let nodeInputPath:     string | undefined
   let nodeInputText:     string | undefined
   let nodeInputMeshPath: string | undefined
+  // Carries forward whatever existing workspace asset fed this run, however many
+  // hops back — set once at the source (mesh node) and passed through untouched
+  // by every node in between, so mesh-exporter can record lineage even at the
+  // end of a multi-step chain.
+  let nodeInputSourceAssetPath: string | undefined
   // Per-slot texts for multi-text-input nodes (e.g. positive/negative prompts).
   // Indexed by target handle: input-0 → texts[0], input-1 → texts[1].
   const nodeInputTexts: (string | undefined)[] = []
@@ -321,6 +334,7 @@ async function executeExtensionNode(
       if (src.outputType === 'mesh')        nodeInputMeshPath = src.filePath
       else if (src.outputType === 'image')  nodeInputPath     = src.filePath
       else if (src.filePath !== undefined)  nodeInputPath     = src.filePath
+      if (src.sourceAssetPath !== undefined) nodeInputSourceAssetPath = src.sourceAssetPath
       if (src.text !== undefined && src.text.trim().length > 0) {
         nodeInputText = src.text
         const slot = /^input-(\d+)$/.exec(edge.targetHandle ?? '')
@@ -331,6 +345,7 @@ async function executeExtensionNode(
     for (const edge of incomingEdges) {
       const src = resolveSource(edge.source)
       if (src?.filePath !== undefined) nodeInputPath = src.filePath
+      if (src?.sourceAssetPath !== undefined) nodeInputSourceAssetPath = src.sourceAssetPath
       if (src?.text !== undefined && src.text.trim().length > 0) nodeInputText = src.text
     }
   }
@@ -433,6 +448,7 @@ async function executeExtensionNode(
         text:     nodeInputText,
         texts:    nodeInputTexts.length > 0 ? nodeInputTexts : undefined,
         nodeId:   nid,
+        sourceAssetPath: nodeInputSourceAssetPath,
       },
       liveParams as Record<string, unknown>,
     )
@@ -443,7 +459,7 @@ async function executeExtensionNode(
   }
 
   const outputType = ext?.output ?? (nodeInputPath ? 'mesh' : undefined)
-  nodeOutputs.set(node.id, { filePath: nodeInputPath, text: nodeInputText, outputType })
+  nodeOutputs.set(node.id, { filePath: nodeInputPath, text: nodeInputText, outputType, sourceAssetPath: nodeInputSourceAssetPath })
 
   const output = nodeOutputs.get(node.id)
   const url = isSceneMeshOutput(output) ? toWorkspaceUrl(output.filePath, workspaceDir) : undefined
@@ -758,10 +774,12 @@ export const useWorkflowRunStore = create<WorkflowRunStore>((set, get) => {
                 const rel = currentMeshUrl.replace(/^\/workspace\//, '')
                 meshFilePath = `${workspaceDir}/${rel}`
               }
-              nodeOutputs.set(node.id, { filePath: meshFilePath, outputType: 'mesh' })
+              // The loaded scene mesh is itself a workspace asset (or a copy of
+              // one) — track it as the lineage source for anything downstream.
+              nodeOutputs.set(node.id, { filePath: meshFilePath, outputType: 'mesh', sourceAssetPath: meshFilePath })
             } else {
               const fp = node.data.params?.filePath as string | undefined
-              if (fp) nodeOutputs.set(node.id, { filePath: fp, outputType: 'mesh' })
+              if (fp) nodeOutputs.set(node.id, { filePath: fp, outputType: 'mesh', sourceAssetPath: fp })
             }
           }
         }

--- a/src/shared/stores/appStore.ts
+++ b/src/shared/stores/appStore.ts
@@ -101,6 +101,12 @@ interface AppState {
   meshSelected: boolean
   setMeshSelected: (selected: boolean) => void
 
+  // Animation clips (set by Viewer3D, read by ChatPanel for agent context)
+  motionClips: { name: string }[]
+  setMotionClips: (clips: { name: string }[]) => void
+  activeClipIndex: number
+  setActiveClipIndex: (index: number) => void
+
   // Setup
   setupStatus:    SetupStatus
   setupProgress:  SetupProgress | null
@@ -262,6 +268,10 @@ export const useAppStore = create<AppState>()(
       setMeshStats: (stats) => set({ meshStats: stats }),
       meshSelected: false,
       setMeshSelected: (selected) => set({ meshSelected: selected }),
+      motionClips: [],
+      setMotionClips: (clips) => set({ motionClips: clips }),
+      activeClipIndex: 0,
+      setActiveClipIndex: (index) => set({ activeClipIndex: index }),
       initApp: async () => {
         set({ backendStatus: 'starting', backendError: null })
 

--- a/src/shared/types/assetLibrary.ts
+++ b/src/shared/types/assetLibrary.ts
@@ -81,3 +81,13 @@ export type AssetLibraryReadResult =
 export type AssetLibraryOpenResult =
   | { success: true, entry: AssetLibraryEntry }
   | { success: false, error: AssetLibraryError }
+
+export interface AssetLibraryThumbnailRequest {
+  workspacePath: string
+}
+
+// Missing thumbnails are an expected, silent condition (not every asset has
+// a rendered preview), so failure carries no error payload for the UI to show.
+export type AssetLibraryThumbnailResult =
+  | { success: true, dataUrl: string }
+  | { success: false }

--- a/src/shared/types/electron.d.ts
+++ b/src/shared/types/electron.d.ts
@@ -60,6 +60,9 @@ export interface ParamSchema {
   // file-select: dropdown of the files inside the folder held by another param
   dir_from?:   string     // id of the (string) param holding the folder path
   extensions?: string[]   // file extensions to list (e.g. ["json"])
+  // Renders a tall, resizable textarea instead of a single-line input,
+  // regardless of the base type (e.g. a "string" param with a long description).
+  multiline?: boolean
 }
 
 export interface ProcessExtension {
@@ -91,6 +94,9 @@ export interface ProcessInput {
   /** Per-slot texts for multi-text-input nodes (index = target handle slot). */
   texts?:    (string | undefined)[]
   nodeId?:   string
+  /** Absolute path of the existing workspace asset this input was sourced from
+   *  (if any) — threaded through the run so mesh-exporter can record lineage. */
+  sourceAssetPath?: string
 }
 
 export interface ProcessResult {

--- a/src/shared/types/electron.d.ts
+++ b/src/shared/types/electron.d.ts
@@ -7,6 +7,8 @@ import type {
   AssetLibraryOpenResult,
   AssetLibraryReadRequest,
   AssetLibraryReadResult,
+  AssetLibraryThumbnailRequest,
+  AssetLibraryThumbnailResult,
 } from './assetLibrary'
 
 // ─── Extension types ──────────────────────────────────────────────────────────
@@ -250,6 +252,7 @@ declare global {
           list: () => Promise<AssetLibraryListResult>
           read: (request: AssetLibraryReadRequest) => Promise<AssetLibraryReadResult>
           open: (request: AssetLibraryOpenRequest) => Promise<AssetLibraryOpenResult>
+          thumbnail: (request: AssetLibraryThumbnailRequest) => Promise<AssetLibraryThumbnailResult>
         }
       }
       setup: {

--- a/src/shared/types/electron.d.ts
+++ b/src/shared/types/electron.d.ts
@@ -49,7 +49,7 @@ export interface ModelExtension {
 export interface ParamSchema {
   id:       string
   label:    string
-  type:     'select' | 'int' | 'float' | 'string' | 'file-select'
+  type:     'select' | 'int' | 'float' | 'string' | 'text' | 'file-select'
   default:  number | string
   options?: { value: number | string; label: string }[]
   min?:     number


### PR DESCRIPTION
Builds on feat/chat-context-lineage (PR #246, still open), which itself builds on feat/desktop-ergonomics (PR #245) -- same head-branch-per-PR-against-main pattern as #242/#243/#244/#246. Scoped entirely to the Library popover in the Generate area; doesn't touch anything #246 changed.

## Problem

The Library popover from #243/#245 works, but the operator flagged it as unusable in real sessions:

- The row list was capped at `max-h-64` (256px) -- with the 80px thumbnail tiles from #243, that's only 2-3 visible rows, in a popup that itself doesn't grow past its content.
- Only the panel's width was resizable; there was no way to make it taller.
- Typing a search query filters correctly, but the collapsed WORKFLOWS/EXPORTS and per-capability groups stay collapsed -- a match hiding inside a collapsed group requires clicking "Show" on every ancestor group by hand before it's visible.
- The search `<input type="search">` renders as a tall box with the placeholder vertically centered in the middle of it, instead of a normal single-line field -- a Chromium `input[type=search]` quirk this codebase never worked around (every other input in this file is `type="number"`/`type="text"`-shaped and unaffected).

## Changes

- **Search auto-expands matches.** `isAssetLibrarySectionExpanded(collapsedSectionKeys, sectionKey, hasActiveSearch)` in `assetLibraryUi.ts` renders a section expanded when either the user left it expanded *or* a search is active. `collapsedSectionKeys` itself is never touched by searching, so clearing the query falls straight back to whatever was collapsed before -- no extra state to keep in sync. The per-section Show/Hide toggle is disabled while a search is active (every visible group already only contains matches, so toggling it would be a dead click that silently changes post-clear state).
- **The listing area now flexes instead of clipping.** The row list is `flex-1 min-h-0 overflow-y-auto overflow-x-hidden` inside a popup with an explicit `height` (from state), rather than a fixed `max-h-64` inside a content-sized popup. The three loading/empty/no-match placeholder states get the same `flex-1` treatment so the popup doesn't collapse to a sliver when there's nothing to show.
- **Height is now drag-resizable and persisted**, mirroring the existing width handle exactly: a second edge handle (`cursor-row-resize`, bottom edge) plus `clampAssetLibraryPanelHeight`/`getStoredAssetLibraryPanelHeight`/`storeAssetLibraryPanelHeight` in `assetLibraryUi.ts`, same shape as the width triple, under its own `modly-library-panel-height` localStorage key. Min/max/default: 280/1000/860.
- **Thumbnail tile shrunk 80px -> 40px, row padding `py-2` -> `py-1.5`.** With 80px tiles, even an 860px-tall popup (near the practical ceiling for a 1080p window before it risks running off-screen) only fits ~4 rows -- nowhere near "a dozen." Shrinking the tile is the only way to reconcile "keep thumbnail tiles" with "usable default size"; everything else about the tile (rounding, border, `object-contain`) is unchanged. At the new size the default popup shows 8-9 full rows before scrolling.
- **Search input fix:** added `appearance-none` to the `type="search"` field, matching the plain box model every other input in this file already gets natively.
- **Incidental fix:** the row's display-name span had no `truncate`/`shrink-0` pairing with its capability badge, so a long filename could overflow the row width and force the scroll container into `overflow-x: auto` (a real single-row case reproduced a visible horizontal scrollbar during verification, sitting right below the intended vertical-only scrollbar). Added `truncate` to the name and `shrink-0` to the badge, plus explicit `overflow-x-hidden` on the list container as a backstop.

## Files changed

- `src/areas/generate/assetLibraryUi.ts` -- `isAssetLibrarySectionExpanded`; height clamp/get/store triple + constants.
- `src/areas/generate/GeneratePage.tsx` -- popup height state/effect/drag handler; search-aware expand + disabled toggle wiring; flex-based list region; smaller thumbnail/tighter row padding; `appearance-none` on the search input; truncate/shrink-0 on the row text row.
- `src/areas/generate/assetLibraryUi.test.ts` -- tests for the new height helpers and `isAssetLibrarySectionExpanded` (searching forces expansion; clearing falls back to the untouched collapsed-key list).

## Verification

Built, packaged (`npm run package`, AppImage target), and installed the same way the currently-running build was installed (asar extracted into `resources/app`, original parked as `app.asar.orig`), replacing the running app on the operator's desktop.

- Typed "villain" (an asset that exists under both Workflows and Exports) into the search field with both groups collapsed beforehand -- WORKFLOWS > Rigged mesh and EXPORTS > Mesh expanded immediately, no clicks, and the search box rendered as a normal single-line field instead of the old tall box. Cleared the field -- both groups fell back to collapsed.
- With a cleared `localStorage` (first-run state), opened the popup and expanded Workflows > Mesh: all 9 entries in that group render fully visible with no scrolling, plus the next group's header peeking in -- up from 2-3 clipped rows before this change.
- Dragged the new bottom-edge handle down; the popup grew past its default height and revealed the next two group headers that had been below the fold.
- Killed and relaunched the app: the popup reopened at the same dragged (non-default) height, not the 860px default.
- Selected an entry post-search and confirmed "Open selected asset" still enables and the status line still updates, to make sure the open flow survived the surrounding JSX changes.
- `npm run lint` and `npm test` (23 Python + 40 Node, including the 3 new assetLibraryUi tests) both pass.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run package` (AppImage) + real install + manual verification on the desktop app
