### PR TITLE
Add shared cuda→mps→cpu device-selection helper (#166)

### DIFF
--- a/api/services/extension_process.py
+++ b/api/services/extension_process.py
@@ -75,6 +75,12 @@ class ExtensionProcess:
         env["MODLY_API_DIR"] = str(Path(__file__).parent.parent)
         if sys.platform == "darwin":
             env.setdefault("NUMBA_DISABLE_JIT", "1")
+            # Must be set before the subprocess's first `import torch` — PyTorch
+            # reads this once to decide whether MPS ops with no Metal kernel
+            # (e.g. 3D pooling) fall back to CPU or raise NotImplementedError.
+            # Setting it inside generator.py is too late, since generator.py
+            # itself imports torch before calling select_device().
+            env.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
         # Pass the exact model_dir so runner.py doesn't have to re-derive it
         # from manifest["id"] (which is the ext_id, not the composite node id).
         # runner.py extracts the node id from MODEL_DIR's trailing path component.

--- a/api/services/generators/base.py
+++ b/api/services/generators/base.py
@@ -11,6 +11,33 @@ class GenerationCancelled(Exception):
     """Raised by generators when a cancel_event is set mid-generation."""
 
 
+def select_device() -> str:
+    """
+    Picks the best torch device available on this machine: CUDA (NVIDIA) ->
+    MPS (Apple Silicon) -> CPU. Extensions should call this instead of
+    hardcoding `.cuda()` / `torch.cuda.is_available()` so device logic lives
+    in one place and Windows/CUDA behavior is unaffected.
+    """
+    import torch
+
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def select_dtype(device: str):
+    """
+    Picks a safe default dtype for `device`. MPS has incomplete fp16 kernel
+    coverage (attention, layer norm, some interpolation ops), so extensions
+    get fp32 there and on CPU; CUDA keeps fp16 for speed/memory.
+    """
+    import torch
+
+    return torch.float16 if device == "cuda" else torch.float32
+
+
 def smooth_progress(
     progress_cb: Callable[[int, str], None],
     start: int,
@@ -83,6 +110,8 @@ class BaseGenerator(ABC):
             import torch
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+            elif torch.backends.mps.is_available():
+                torch.mps.empty_cache()
         except ImportError:
             pass
         # Force the OS to reclaim unused memory from this process

--- a/api/services/generators/base.py
+++ b/api/services/generators/base.py
@@ -17,12 +17,22 @@ def select_device() -> str:
     MPS (Apple Silicon) -> CPU. Extensions should call this instead of
     hardcoding `.cuda()` / `torch.cuda.is_available()` so device logic lives
     in one place and Windows/CUDA behavior is unaffected.
+
+    PyTorch only falls back to CPU for MPS ops with no Metal kernel (e.g. 3D
+    pooling) — instead of raising NotImplementedError — if
+    PYTORCH_ENABLE_MPS_FALLBACK=1 is set *before the process's first `import
+    torch`*. That's set for every extension subprocess in
+    ExtensionProcess._build_env(); the setdefault() below is just a
+    best-effort backstop for callers that reach select_device() before
+    importing torch themselves.
     """
+    import os
     import torch
 
     if torch.cuda.is_available():
         return "cuda"
     if torch.backends.mps.is_available():
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
         return "mps"
     return "cpu"
 


### PR DESCRIPTION
Part of #166 (FEATURE 5 — macOS support for all models).

`BaseGenerator` subclasses currently hardcode `torch.cuda.is_available()`,
so model extensions only run on Windows/Linux with an NVIDIA GPU. This adds
two small helpers to `api/services/generators/base.py`:

- `select_device()` — picks `cuda` → `mps` (Apple Silicon) → `cpu`.
- `select_dtype(device)` — `float16` on CUDA, `float32` on MPS/CPU (MPS has
  incomplete fp16 kernel coverage for attention/layer-norm/interpolation).

`BaseGenerator.unload()` now also releases MPS memory via
`torch.mps.empty_cache()` (it already did this for CUDA).

Extensions import these from `services.generators.base` the same way they
already import `smooth_progress`/`GenerationCancelled`, so device logic
lives in one place instead of being duplicated per extension, per the
ticket's implementation notes.

**Companion extension PR:** lightningpixel/modly-triposg-extension uses
these helpers — see that PR for the per-model changes.

**Status of the other three models in the ticket**, for visibility:
- Hunyuan3D 2 Mini / Mini Turbo already have working MPS support merged on
  `main` (PR #11 on modly-hunyuan3d-mini-extension, and an equivalent commit
  on modly-hunyuan3d-mini-turbo-extension) — no changes needed there.
- Trellis2 GGUF depends on `spconv` for its sparse convolutions, which has
  no CPU or Metal/MPS backend at all (only an unsupported Linux-only debug
  CPU build) — full MPS support isn't achievable without replacing that
  dependency, so it's out of scope for this pass.

**No frontend/store/API surface changes.** Windows/CUDA behavior is
unchanged (`torch.cuda.is_available()` is still checked first everywhere).
