### PR TITLE
Fix Modly CLI JSON argument handling

### DIFF
--- a/tools/modly-cli/agent.py
+++ b/tools/modly-cli/agent.py
@@ -1180,8 +1180,13 @@ def _add_serve_options(parser: argparse.ArgumentParser, *, include_start: bool =
     parser.add_argument("--print-command", action="store_true", help="Print resolved command/env without starting")
 
 
+class JsonArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise ModlyCliError(message, code="INVALID_ARGUMENTS")
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = JsonArgumentParser(
         prog="modly-cli",
         description="Tiny stdlib-only CLI for agents calling a running Modly desktop API.",
     )
@@ -1335,6 +1340,13 @@ def main(argv: list[str] | None = None) -> int:
         return int(args.func(args))
     except ModlyCliError as exc:
         _json_print({"ok": False, "code": exc.code, "message": exc.message, "error": exc.message}, compact=getattr(args, "compact", False) if args else False)
+        return 1
+    except SystemExit as exc:
+        code = exc.code
+        if code in (None, 0):
+            return 0
+        message = str(code)
+        _json_print({"ok": False, "code": "INVALID_ARGUMENTS", "message": message, "error": message}, compact=getattr(args, "compact", False) if args else False)
         return 1
     except KeyboardInterrupt:
         _json_print({"ok": False, "code": "INTERRUPTED", "message": "interrupted", "error": "interrupted"}, compact=getattr(args, "compact", False) if args else False)

--- a/tools/modly-cli/test_agent.py
+++ b/tools/modly-cli/test_agent.py
@@ -262,6 +262,13 @@ class CommandTests(unittest.TestCase):
         self.assertEqual(payload["code"], "UNEXPECTED_ERROR")
         self.assertEqual(payload["message"], "boom")
 
+    def test_main_converts_argparse_errors_to_json(self) -> None:
+        with redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(agent.main(["health", "--bogus"]), 1)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["code"], "INVALID_ARGUMENTS")
+        self.assertIn("--bogus", payload["message"])
+
     def test_generate_from_workflow_downloads_direct_asset_without_modly_health(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             output = Path(td) / "robot.glb"


### PR DESCRIPTION
## Summary

The Modly CLI should keep returning machine-readable JSON even when argparse rejects an invalid flag or missing command. Before this change, malformed CLI input could trigger raw `SystemExit`/usage output, which broke automation and made the CLI fail in a non-contractual way.

## What changed

- Added a custom argparse parser that converts validation failures into `ModlyCliError(code="INVALID_ARGUMENTS")`.
- Updated the top-level CLI handler to emit the standard JSON error envelope instead of escaping as raw argparse output.
- Added a regression test covering invalid CLI arguments so this contract stays protected.

This keeps automation callers on the same JSON contract while preserving normal CLI help behavior for valid invocations.