### PR TITLE
feat(process): pass models directory to Python extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ Modly supports external model and process extensions. Each extension is a GitHub
 
 ![Install models](docs/install-models.png)
 
+### Python process storage paths
+
+When a Python process extension is installed from GitHub or repaired, Modly invokes its `setup.py` with the existing single JSON argument. In addition to the legacy fields, that object contains `models_dir`: the normalized, native absolute path configured as Modly's models directory.
+
+For each Python process run, the single JSON line written to standard input contains the normalized native absolute `modelsDir` alongside the existing host-provided `workspaceDir` and `tempDir` paths. The new storage-path fields do not expose the settings object, raw profiles, environment-derived paths, credentials, tokens, or hardware details; setup's existing platform and accelerator fields remain unchanged. JavaScript process extensions keep their existing context unchanged.
+
+A process extension is responsible for selecting its own subdirectory, provisioning and validating its assets, avoiding collisions with other extensions, and removing assets it no longer needs. Uninstalling an extension removes its extension directory only; Modly does not automatically remove process-owned assets from `modelsDir`.
+
 ---
 
 ## Workflows

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -18,6 +18,7 @@ import { getSettings, setSettings } from './settings-store'
 import { checkSetupNeeded, markSetupDone, runFullSetup, getVenvPythonExe, ensureSslPatch } from './python-setup'
 import { logger } from './logger'
 import { getProcessRunner, getPythonProcessRunner, getExtPythonExe, terminateProcessRunner, terminateAllProcessRunners } from './process-runner'
+import { buildExtensionSetupPayload, cudaVersionForDriverVersion, isSupportedExtensionSetup } from './process-extension-contract'
 import { getBuiltinExtensionsDir } from './builtin-sync'
 import { spawn, execFile } from 'child_process'
 import {
@@ -64,20 +65,10 @@ function detectGpuInfo(): Promise<GpuInfo> {
         const line   = out.trim().split('\n')[0].trim()        // e.g. "8.6, 551.61"
         const parts  = line.split(',').map(s => s.trim())
         const sm     = Math.round(parseFloat(parts[0] ?? '') * 10)  // → 86
-        // Derive max supported CUDA version from driver version
-        // Driver ≥ 520 → CUDA 11.8, ≥ 525 → 12.0, ≥ 530 → 12.1, ≥ 535 → 12.2,
-        // ≥ 545 → 12.3, ≥ 550 → 12.4, ≥ 555 → 12.5, ≥ 560 → 12.6
-        const driverMajor = parseInt((parts[1] ?? '').split('.')[0] ?? '0', 10)
-        let cudaVersion = 118  // safe minimum
-        if      (driverMajor >= 570) cudaVersion = 128  // Blackwell (RTX 50xx, sm_120)
-        else if (driverMajor >= 560) cudaVersion = 126
-        else if (driverMajor >= 555) cudaVersion = 125
-        else if (driverMajor >= 550) cudaVersion = 124
-        else if (driverMajor >= 545) cudaVersion = 123
-        else if (driverMajor >= 535) cudaVersion = 122
-        else if (driverMajor >= 530) cudaVersion = 121
-        else if (driverMajor >= 525) cudaVersion = 120
-        else if (driverMajor >= 520) cudaVersion = 118
+        // Derive the setup compatibility branch from the installed driver.
+        // NVIDIA's minor-version compatibility boundary is R580 for CUDA 13.x;
+        // R570–R579 remains on the CUDA 12.8 setup branch.
+        const cudaVersion = cudaVersionForDriverVersion(parts[1] ?? '')
         resolve({ sm: isNaN(sm) ? 86 : sm, cudaVersion, accelerator: 'cuda' })
       } else {
         resolve({ sm: 0, cudaVersion: 0, accelerator: 'cpu' })
@@ -94,6 +85,7 @@ function runExtensionSetup(
   gpuSm:       number,
   cudaVersion: number,
   onLog?:      (line: string) => void,
+  modelsDir?:  string,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const userData  = app.getPath('userData')
@@ -108,15 +100,16 @@ function runExtensionSetup(
     try { mkdirSync(pipCacheDir, { recursive: true }) } catch { /* pip creates it too */ }
 
     const accelerator = process.platform === 'darwin' && process.arch === 'arm64' ? 'mps' : gpuSm > 0 ? 'cuda' : 'cpu'
-    const args = JSON.stringify({
-      python_exe: pythonExe,
-      ext_dir: extDir,
-      gpu_sm: gpuSm,
-      cuda_version: cudaVersion,
+    const args = JSON.stringify(buildExtensionSetupPayload({
+      pythonExe,
+      extDir,
+      gpuSm,
+      cudaVersion,
       accelerator,
       platform: process.platform,
       arch: process.arch,
-    })
+      modelsDir,
+    }))
     const launcher = `
 import runpy
 import subprocess
@@ -908,7 +901,15 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
     }[]
   }
 
-  function parseExtensionManifest(parsed: ParsedManifest, fallbackId: string, trustedRepos: Set<string>, builtin = false) {
+  function parseExtensionManifest(
+    parsed: ParsedManifest,
+    fallbackId: string,
+    trustedRepos: Set<string>,
+    builtin = false,
+    extensionDir?: string,
+  ) {
+    const processEntry = parsed.entry ?? 'processor.js'
+    const hasSetup = extensionDir !== undefined && existsSync(join(extensionDir, 'setup.py'))
     const common = {
       id:          parsed.id          ?? fallbackId,
       name:        parsed.displayName ?? parsed.name ?? fallbackId,
@@ -918,6 +919,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       trusted:     builtin || isTrustedSource(parsed.source, trustedRepos),
       source:      parsed.source,
       builtin,
+      repairable:  isSupportedExtensionSetup(parsed.type, processEntry, hasSetup),
     }
 
     const nodes = (parsed.nodes ?? []).map(n => ({
@@ -936,7 +938,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
     }))
 
     if (parsed.type === 'process') {
-      return { ...common, type: 'process' as const, entry: parsed.entry ?? 'processor.js', nodes }
+      return { ...common, type: 'process' as const, entry: processEntry, nodes }
     }
 
     return { ...common, type: 'model' as const, nodes }
@@ -998,7 +1000,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
                 const parsed = JSON.parse(raw) as ParsedManifest
                 // Inject local:// source so the UI shows the Local badge
                 if (localSourcePath) parsed.source = `local://${localSourcePath}`
-                return parseExtensionManifest(parsed, entry.name, trustedRepos, isBuiltin)
+                return parseExtensionManifest(parsed, entry.name, trustedRepos, isBuiltin, entryPath)
               } catch { manifestError = 'invalid' }
             }
           }
@@ -1097,7 +1099,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       //    paths, so the folder must not move after setup. If anything dies
       //    mid-way, the marker + backup let the startup reconciler put the
       //    previous version back.
-      const extensionsDir = getSettings(app.getPath('userData')).extensionsDir
+      const { extensionsDir, modelsDir } = getSettings(app.getPath('userData'))
       await mkdir(extensionsDir, { recursive: true })
       const destDir    = resolveExtensionPathWithinRoot(extensionsDir, extensionId)
       const stagingDir = buildExtensionStagingPath(extensionsDir, extensionId, String(Date.now()))
@@ -1153,7 +1155,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
             await runExtensionSetup(destDir, gpuSm, cudaVersion, (line) => {
               logger.info(`[ext-setup] ${line}`)
               emit({ step: 'setting_up', message: line })
-            })
+            }, modelsDir)
           }
         } else if (isProcess) {
           // 7b. JS process extension: npm install if package.json present
@@ -1218,7 +1220,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       emit({ step: 'done', extensionId })
 
       const trustedRepos = await fetchTrustedRepos()
-      const ext = parseExtensionManifest(manifest, extensionId, trustedRepos)
+      const ext = parseExtensionManifest(manifest, extensionId, trustedRepos, false, destDir)
       return { success: true, extensionId, extension: ext }
 
     } catch (err) {
@@ -1271,16 +1273,23 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
     }
   })
 
-  // Re-run setup.py for a model extension (creates the venv if missing)
+  // Re-run setup.py for a Python-backed extension (creates the venv if missing)
   ipcMain.handle('extensions:repair', async (_, extensionId: string) => {
     try {
       const safeExtensionId = assertSafeExtensionId(extensionId)
-      const extDir = resolveExtensionPathWithinRoot(getSettings(app.getPath('userData')).extensionsDir, safeExtensionId)
+      const { extensionsDir, modelsDir } = getSettings(app.getPath('userData'))
+      const extDir = resolveExtensionPathWithinRoot(extensionsDir, safeExtensionId)
       if (!existsSync(join(extDir, 'setup.py'))) {
         return { success: false, error: 'setup.py is missing from the extension folder — the install looks incomplete. Uninstall the extension and install it again.' }
       }
+      let processModelsDir: string | undefined
+      try {
+        const manifest = JSON.parse(await readFile(join(extDir, 'manifest.json'), 'utf-8')) as ParsedManifest
+        const entry = manifest.entry ?? 'processor.js'
+        if (manifest.type === 'process' && entry.endsWith('.py')) processModelsDir = modelsDir
+      } catch { /* Preserve legacy repair behavior for folders without a readable manifest. */ }
       const { sm: gpuSm, cudaVersion } = await detectGpuInfo()
-      await runExtensionSetup(extDir, gpuSm, cudaVersion, (line) => logger.info(`[ext-repair] ${line}`))
+      await runExtensionSetup(extDir, gpuSm, cudaVersion, (line) => logger.info(`[ext-repair] ${line}`), processModelsDir)
       try {
         await axios.post(`${API_BASE_URL}/extensions/reload`, {}, { timeout: 10_000 })
       } catch { /* ignore if Python is not running yet */ }
@@ -1374,7 +1383,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       const trustedRepos = await fetchTrustedRepos()
       // Build manifest with localPath marker so the UI can identify local extensions
       const annotatedManifest = { ...manifest, source: `local://${localPath}` }
-      const ext = parseExtensionManifest(annotatedManifest, extensionId, trustedRepos)
+      const ext = parseExtensionManifest(annotatedManifest, extensionId, trustedRepos, false, localPath)
       return { success: true, extensionId, extension: ext, localPath }
 
     } catch (err) {
@@ -1397,7 +1406,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
   // Run a process extension in an isolated worker thread
   ipcMain.handle('extensions:runProcess', async (_, extensionId: string, input: { filePath?: string; text?: string; texts?: (string | undefined)[]; nodeId?: string }, params: Record<string, unknown>) => {
     const userData        = app.getPath('userData')
-    const { extensionsDir, workspaceDir } = getSettings(userData)
+    const { extensionsDir, modelsDir, workspaceDir } = getSettings(userData)
 
     // Resolve extension directory: check built-ins first, then user extensions
     const builtinExtDir = join(getBuiltinExtensionsDir(), extensionId)
@@ -1418,7 +1427,7 @@ export function setupIpcHandlers(pythonBridge: PythonBridge, getWindow: WindowGe
       let runner
       if (isPythonEntry) {
         const pythonExe = getExtPythonExe(extDir) ?? getVenvPythonExe(userData)
-        runner = getPythonProcessRunner(extensionId, pythonExe, extDir, entry, workspaceDir, app.getPath('temp'))
+        runner = getPythonProcessRunner(extensionId, pythonExe, extDir, entry, modelsDir, workspaceDir, app.getPath('temp'))
       } else {
         runner = getProcessRunner(extensionId, extDir, entry, workspaceDir, app.getPath('temp'))
       }

--- a/electron/main/process-extension-contract.test.mjs
+++ b/electron/main/process-extension-contract.test.mjs
@@ -1,0 +1,303 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildSync } from 'esbuild'
+import { createRequire } from 'node:module'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+function loadModule(entry) {
+  const name = entry.split('/').at(-1).replace(/\.ts$/, '.cjs')
+  const outfile = join(mkdtempSync(join(tmpdir(), 'modly-process-contract-test-')), name)
+  const require = createRequire(import.meta.url)
+  const result = buildSync({
+    entryPoints: [resolve(entry)],
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    write: false,
+  })
+  writeFileSync(outfile, result.outputFiles[0].text, 'utf8')
+  return require(outfile)
+}
+
+test('Python PROCESS setup payload adds only the configured Windows models directory', () => {
+  const { buildExtensionSetupPayload } = loadModule('electron/main/process-extension-contract.ts')
+
+  const payload = buildExtensionSetupPayload({
+    pythonExe: 'C:\\Program Files\\Modly\\python.exe',
+    extDir: 'C:\\Users\\Jane Doe\\Modly Extensions\\voice',
+    gpuSm: 86,
+    cudaVersion: 124,
+    accelerator: 'cuda',
+    platform: 'win32',
+    arch: 'x64',
+    modelsDir: 'C:\\Users\\Jane Doe\\Modly Models',
+  })
+
+  assert.deepEqual(payload, {
+    python_exe: 'C:\\Program Files\\Modly\\python.exe',
+    ext_dir: 'C:\\Users\\Jane Doe\\Modly Extensions\\voice',
+    gpu_sm: 86,
+    cuda_version: 124,
+    accelerator: 'cuda',
+    platform: 'win32',
+    arch: 'x64',
+    models_dir: 'C:\\Users\\Jane Doe\\Modly Models',
+  })
+  assert.deepEqual(
+    Object.keys(payload),
+    ['python_exe', 'ext_dir', 'gpu_sm', 'cuda_version', 'accelerator', 'platform', 'arch', 'models_dir'],
+  )
+  for (const forbidden of ['hfToken', 'HF_TOKEN', 'token', 'secret', 'settings', 'profile', 'userData']) {
+    assert.equal(Object.hasOwn(payload, forbidden), false)
+  }
+})
+
+test('setup payload without modelsDir preserves the legacy shape', () => {
+  const { buildExtensionSetupPayload } = loadModule('electron/main/process-extension-contract.ts')
+
+  assert.deepEqual(buildExtensionSetupPayload({
+    pythonExe: '/opt/modly/python',
+    extDir: '/home/jane doe/extensions/model',
+    gpuSm: 0,
+    cudaVersion: 0,
+    accelerator: 'cpu',
+    platform: 'linux',
+    arch: 'x64',
+  }), {
+    python_exe: '/opt/modly/python',
+    ext_dir: '/home/jane doe/extensions/model',
+    gpu_sm: 0,
+    cuda_version: 0,
+    accelerator: 'cpu',
+    platform: 'linux',
+    arch: 'x64',
+  })
+})
+
+test('host advertises Repair only for supported setup.py routes', () => {
+  const { isSupportedExtensionSetup } = loadModule('electron/main/process-extension-contract.ts')
+
+  assert.equal(isSupportedExtensionSetup('model', 'generator.py', true), true)
+  assert.equal(isSupportedExtensionSetup('process', 'processor.py', true), true)
+  assert.equal(isSupportedExtensionSetup('process', 'processor.py', false), false)
+  assert.equal(isSupportedExtensionSetup('process', 'processor.js', true), false)
+})
+
+test('NVIDIA driver boundaries select CUDA 13.0 only for R580 and newer', () => {
+  const { cudaVersionForDriverVersion } = loadModule('electron/main/process-extension-contract.ts')
+
+  assert.equal(cudaVersionForDriverVersion('579.99'), 128)
+  assert.equal(cudaVersionForDriverVersion('580.00'), 130)
+  assert.equal(cudaVersionForDriverVersion('570.26'), 128)
+  assert.equal(cudaVersionForDriverVersion('569.99'), 126)
+  assert.equal(cudaVersionForDriverVersion('not-a-version'), 118)
+})
+
+test('R580 CUDA 13.0 metadata reaches the Python setup JSON payload', () => {
+  const { buildExtensionSetupPayload, cudaVersionForDriverVersion } = loadModule('electron/main/process-extension-contract.ts')
+
+  const payload = buildExtensionSetupPayload({
+    pythonExe: '/opt/modly/python',
+    extDir: '/home/jane/extensions/python-process',
+    gpuSm: 90,
+    cudaVersion: cudaVersionForDriverVersion('580.65.06'),
+    accelerator: 'cuda',
+    platform: 'linux',
+    arch: 'x64',
+    modelsDir: '/home/jane/Modly Models',
+  })
+
+  assert.equal(payload.cuda_version, 130)
+  assert.equal(payload.models_dir, '/home/jane/Modly Models')
+})
+
+test('configured native paths are absolute, normalized, and preserve spaces and backslashes', () => {
+  const { normalizeConfiguredDirectoryPath } = loadModule('electron/main/process-extension-contract.ts')
+
+  assert.equal(
+    normalizeConfiguredDirectoryPath('C:\\Users\\Jane Doe\\Modly Models\\..\\Models Library', 'modelsDir', 'win32'),
+    'C:\\Users\\Jane Doe\\Models Library',
+  )
+  assert.equal(
+    normalizeConfiguredDirectoryPath('/home/jane doe/Modly Models/../models', 'modelsDir', 'linux'),
+    '/home/jane doe/models',
+  )
+  assert.throws(
+    () => normalizeConfiguredDirectoryPath('relative/models', 'modelsDir', 'linux'),
+    /modelsDir.*absolute/i,
+  )
+  assert.throws(
+    () => normalizeConfiguredDirectoryPath('models\\relative', 'modelsDir', 'win32'),
+    /modelsDir.*absolute/i,
+  )
+  assert.throws(
+    () => normalizeConfiguredDirectoryPath('\\Models', 'modelsDir', 'win32'),
+    /modelsDir.*absolute/i,
+  )
+  assert.throws(
+    () => normalizeConfiguredDirectoryPath('/Models', 'modelsDir', 'win32'),
+    /modelsDir.*absolute/i,
+  )
+  assert.throws(
+    () => normalizeConfiguredDirectoryPath('/tmp/models\0private', 'modelsDir', 'linux'),
+    /modelsDir.*null/i,
+  )
+})
+
+test('Python PROCESS runtime normalizes modelsDir without changing legacy paths', () => {
+  const { buildPythonProcessPayload } = loadModule('electron/main/process-extension-contract.ts')
+
+  const payload = buildPythonProcessPayload(
+    { text: 'hello', nodeId: 'node-7' },
+    { voice: 'Ryan' },
+    {
+      modelsDir: 'C:\\Modly Data\\models dir\\..\\models library',
+      workspaceDir: 'C:\\Modly Data\\workspace dir\\..\\legacy workspace',
+      tempDir: 'C:\\Users\\Jane Doe\\AppData\\Local\\Temp',
+    },
+    'win32',
+  )
+
+  assert.deepEqual(payload, {
+    input: { text: 'hello', nodeId: 'node-7' },
+    params: { voice: 'Ryan' },
+    nodeId: 'node-7',
+    modelsDir: 'C:\\Modly Data\\models library',
+    workspaceDir: 'C:\\Modly Data\\workspace dir\\..\\legacy workspace',
+    tempDir: 'C:\\Users\\Jane Doe\\AppData\\Local\\Temp',
+  })
+  for (const forbidden of ['hfToken', 'HF_TOKEN', 'token', 'secret', 'settings', 'profile', 'userData', 'gpu', 'hardware']) {
+    assert.equal(Object.hasOwn(payload, forbidden), false)
+  }
+})
+
+test('PythonProcessRunner sends modelsDir on stdin and preserves NDJSON result semantics', async () => {
+  const { PythonProcessRunner } = loadModule('electron/main/process-runner.ts')
+  const extDir = mkdtempSync(join(tmpdir(), 'modly-python-process-test-'))
+  const entry = 'echo.py'
+  writeFileSync(join(extDir, entry), `
+let input = ''
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', (chunk) => { input += chunk })
+process.stdin.on('end', () => {
+  const payload = JSON.parse(input.trim())
+  process.stdout.write(JSON.stringify({ type: 'done', result: { text: JSON.stringify(payload) } }) + '\\n')
+})
+`, 'utf8')
+
+  const runner = new PythonProcessRunner(
+    process.execPath,
+    extDir,
+    entry,
+    '/home/jane doe/Modly Models',
+    '/home/jane doe/Modly Workspace',
+    '/tmp/Modly Runtime',
+  )
+  const result = await runner.run(
+    { text: 'hello', nodeId: 'node-9' },
+    { speed: 1.1 },
+  )
+  const payload = JSON.parse(result.text)
+
+  assert.deepEqual(payload, {
+    input: { text: 'hello', nodeId: 'node-9' },
+    params: { speed: 1.1 },
+    nodeId: 'node-9',
+    modelsDir: '/home/jane doe/Modly Models',
+    workspaceDir: '/home/jane doe/Modly Workspace',
+    tempDir: '/tmp/Modly Runtime',
+  })
+  assert.equal(Object.hasOwn(payload, 'settings'), false)
+  assert.equal(Object.hasOwn(payload, 'hfToken'), false)
+})
+
+test('cached Python runner refreshes its executable, entry, and configured storage paths before each run', async () => {
+  const { getPythonProcessRunner, terminateProcessRunner } = loadModule('electron/main/process-runner.ts')
+  const oldExtDir = mkdtempSync(join(tmpdir(), 'modly-python-process-cache-old-test-'))
+  const newExtDir = mkdtempSync(join(tmpdir(), 'modly-python-process-cache-new-test-'))
+  const oldEntry = 'old.py'
+  const newEntry = 'new.py'
+  const extensionId = `process-path-refresh-${Date.now()}`
+  writeFileSync(join(oldExtDir, oldEntry), `
+process.stdout.write(JSON.stringify({ type: 'error', message: 'stale runner configuration' }) + '\\n')
+`, 'utf8')
+  writeFileSync(join(newExtDir, newEntry), `
+let input = ''
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', (chunk) => { input += chunk })
+process.stdin.on('end', () => {
+  process.stdout.write(JSON.stringify({ type: 'done', result: { text: input.trim() } }) + '\\n')
+})
+`, 'utf8')
+
+  try {
+    const first = getPythonProcessRunner(
+      extensionId,
+      '/definitely/missing/python',
+      oldExtDir,
+      oldEntry,
+      '/home/jane doe/Old Models',
+      '/home/jane doe/Old Workspace',
+      '/tmp/Old Runtime',
+    )
+    const second = getPythonProcessRunner(
+      extensionId,
+      process.execPath,
+      newExtDir,
+      newEntry,
+      '/home/jane doe/New Models',
+      '/home/jane doe/New Workspace',
+      '/tmp/New Runtime',
+    )
+
+    assert.equal(second, first)
+    const payload = JSON.parse((await second.run({ nodeId: 'node-refresh' }, {})).text)
+    assert.equal(payload.modelsDir, '/home/jane doe/New Models')
+    assert.equal(payload.workspaceDir, '/home/jane doe/New Workspace')
+    assert.equal(payload.tempDir, '/tmp/New Runtime')
+  } finally {
+    terminateProcessRunner(extensionId)
+  }
+})
+
+test('JavaScript ProcessRunner context remains unchanged and excludes modelsDir', async () => {
+  const { ProcessRunner } = loadModule('electron/main/process-runner.ts')
+  const extDir = mkdtempSync(join(tmpdir(), 'modly-js-process-test-'))
+  const entry = 'processor.cjs'
+  writeFileSync(join(extDir, entry), `
+module.exports = async (input, params, context) => ({
+  text: JSON.stringify({
+    input,
+    params,
+    contextKeys: Object.keys(context).sort(),
+    workspaceDir: context.workspaceDir,
+    tempDir: context.tempDir,
+    nodeId: context.nodeId,
+    hasModelsDir: Object.hasOwn(context, 'modelsDir'),
+  }),
+})
+`, 'utf8')
+
+  const runner = new ProcessRunner(
+    extDir,
+    entry,
+    '/home/jane doe/Modly Workspace',
+    '/tmp/Modly Runtime',
+  )
+  try {
+    const result = await runner.run({ text: 'hello', nodeId: 'node-js' }, { quality: 'high' })
+    assert.deepEqual(JSON.parse(result.text), {
+      input: { text: 'hello', nodeId: 'node-js' },
+      params: { quality: 'high' },
+      contextKeys: ['log', 'nodeId', 'progress', 'tempDir', 'workspaceDir'],
+      workspaceDir: '/home/jane doe/Modly Workspace',
+      tempDir: '/tmp/Modly Runtime',
+      nodeId: 'node-js',
+      hasModelsDir: false,
+    })
+  } finally {
+    runner.terminate()
+  }
+})

--- a/electron/main/process-extension-contract.ts
+++ b/electron/main/process-extension-contract.ts
@@ -1,0 +1,108 @@
+import { posix, win32 } from 'path'
+
+type SetupAccelerator = 'cuda' | 'mps' | 'cpu'
+
+interface ExtensionSetupPayloadInput {
+  pythonExe:    string
+  extDir:       string
+  gpuSm:        number
+  cudaVersion:  number
+  accelerator:  SetupAccelerator
+  platform:     NodeJS.Platform
+  arch:         string
+  modelsDir?:   string
+}
+
+export interface ExtensionSetupPayload {
+  python_exe:   string
+  ext_dir:      string
+  gpu_sm:       number
+  cuda_version: number
+  accelerator:  SetupAccelerator
+  platform:     NodeJS.Platform
+  arch:         string
+  models_dir?:  string
+}
+
+interface PythonProcessPaths {
+  modelsDir:    string
+  workspaceDir: string
+  tempDir:      string
+}
+
+export function isSupportedExtensionSetup(
+  extensionType: 'model' | 'process' | undefined,
+  entry: string,
+  hasSetup: boolean,
+): boolean {
+  return hasSetup && (extensionType !== 'process' || entry.endsWith('.py'))
+}
+
+export function cudaVersionForDriverVersion(driverVersion: string): number {
+  const driverMajor = Number.parseInt(driverVersion.split('.')[0] ?? '', 10)
+  if (driverMajor >= 580) return 130
+  if (driverMajor >= 570) return 128
+  if (driverMajor >= 560) return 126
+  if (driverMajor >= 555) return 125
+  if (driverMajor >= 550) return 124
+  if (driverMajor >= 545) return 123
+  if (driverMajor >= 535) return 122
+  if (driverMajor >= 530) return 121
+  if (driverMajor >= 525) return 120
+  return 118
+}
+
+export function normalizeConfiguredDirectoryPath(
+  value: string,
+  label: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty absolute path`)
+  }
+  if (value.includes('\0')) {
+    throw new Error(`${label} must not contain null bytes`)
+  }
+
+  const nativePath = platform === 'win32' ? win32 : posix
+  const isAbsolute = platform === 'win32'
+    ? /^(?:[A-Za-z]:[\\/]|[\\/]{2}[^\\/]+[\\/][^\\/]+)/.test(value)
+    : nativePath.isAbsolute(value)
+  if (!isAbsolute) {
+    throw new Error(`${label} must be an absolute ${platform} path`)
+  }
+  return nativePath.normalize(value)
+}
+
+export function buildExtensionSetupPayload(input: ExtensionSetupPayloadInput): ExtensionSetupPayload {
+  const payload: ExtensionSetupPayload = {
+    python_exe:   input.pythonExe,
+    ext_dir:      input.extDir,
+    gpu_sm:       input.gpuSm,
+    cuda_version: input.cudaVersion,
+    accelerator:  input.accelerator,
+    platform:     input.platform,
+    arch:         input.arch,
+  }
+
+  if (input.modelsDir !== undefined) {
+    payload.models_dir = normalizeConfiguredDirectoryPath(input.modelsDir, 'modelsDir', input.platform)
+  }
+  return payload
+}
+
+export function buildPythonProcessPayload<TInput extends { nodeId?: string }>(
+  input: TInput,
+  params: Record<string, unknown>,
+  paths: PythonProcessPaths,
+  platform: NodeJS.Platform = process.platform,
+) {
+  return {
+    input,
+    params,
+    nodeId:       input.nodeId ?? '',
+    modelsDir:    normalizeConfiguredDirectoryPath(paths.modelsDir, 'modelsDir', platform),
+    workspaceDir: paths.workspaceDir,
+    tempDir:      paths.tempDir,
+  }
+}

--- a/electron/main/process-runner.ts
+++ b/electron/main/process-runner.ts
@@ -2,6 +2,7 @@ import { Worker }      from 'worker_threads'
 import { spawn }       from 'child_process'
 import { existsSync }  from 'fs'
 import { join }        from 'path'
+import { buildPythonProcessPayload } from './process-extension-contract'
 
 // ─── Worker code for JS process extensions ────────────────────────────────────
 
@@ -155,18 +156,35 @@ export class ProcessRunner implements IProcessRunner {
 
 // ─── Python ProcessRunner (subprocess, one process per run) ───────────────────
 //
-// Protocol — stdin:  one JSON line  { input, params, workspaceDir, tempDir }
+// Protocol — stdin:  one JSON line  { input, params, modelsDir, workspaceDir, tempDir }
 // Protocol — stdout: JSON lines     { type: 'progress'|'log'|'done'|'error', ... }
 
 export class PythonProcessRunner implements IProcessRunner {
   private pythonExe:    string
   private scriptPath:   string
+  private modelsDir:    string
   private workspaceDir: string
   private tempDir:      string
 
-  constructor(pythonExe: string, extDir: string, entry: string, workspaceDir: string, tempDir: string) {
+  constructor(pythonExe: string, extDir: string, entry: string, modelsDir: string, workspaceDir: string, tempDir: string) {
     this.pythonExe    = pythonExe
     this.scriptPath   = join(extDir, entry)
+    this.modelsDir    = modelsDir
+    this.workspaceDir = workspaceDir
+    this.tempDir      = tempDir
+  }
+
+  updateRuntime(
+    pythonExe: string,
+    extDir: string,
+    entry: string,
+    modelsDir: string,
+    workspaceDir: string,
+    tempDir: string,
+  ): void {
+    this.pythonExe    = pythonExe
+    this.scriptPath   = join(extDir, entry)
+    this.modelsDir    = modelsDir
     this.workspaceDir = workspaceDir
     this.tempDir      = tempDir
   }
@@ -177,19 +195,19 @@ export class PythonProcessRunner implements IProcessRunner {
     onProgress?: (percent: number, label: string) => void,
     onLog?:      (message: string) => void,
   ): Promise<ProcessResult> {
+    const payload = buildPythonProcessPayload(input, params, {
+      modelsDir:    this.modelsDir,
+      workspaceDir: this.workspaceDir,
+      tempDir:      this.tempDir,
+    })
+
     return new Promise((resolve, reject) => {
       const proc = spawn(this.pythonExe, [this.scriptPath], {
         stdio: ['pipe', 'pipe', 'pipe'],
       })
 
       // Send input as a single JSON line on stdin
-      proc.stdin.write(JSON.stringify({
-        input,
-        params,
-        nodeId:       input.nodeId ?? '',
-        workspaceDir: this.workspaceDir,
-        tempDir:      this.tempDir,
-      }) + '\n')
+      proc.stdin.write(JSON.stringify(payload) + '\n')
       proc.stdin.end()
 
       let stdoutBuf = ''
@@ -286,13 +304,21 @@ export function getPythonProcessRunner(
   pythonExe:    string,
   extDir:       string,
   entry:        string,
+  modelsDir:    string,
   workspaceDir: string,
   tempDir:      string,
 ): PythonProcessRunner {
-  if (!registry.has(extensionId)) {
-    registry.set(extensionId, new PythonProcessRunner(pythonExe, extDir, entry, workspaceDir, tempDir))
+  const existing = registry.get(extensionId)
+  if (existing instanceof PythonProcessRunner) {
+    existing.updateRuntime(pythonExe, extDir, entry, modelsDir, workspaceDir, tempDir)
+    return existing
   }
-  return registry.get(extensionId)! as PythonProcessRunner
+  if (!existing) {
+    const runner = new PythonProcessRunner(pythonExe, extDir, entry, modelsDir, workspaceDir, tempDir)
+    registry.set(extensionId, runner)
+    return runner
+  }
+  return existing as PythonProcessRunner
 }
 
 export function terminateProcessRunner(extensionId: string): void {

--- a/src/areas/models/ModelsPage.tsx
+++ b/src/areas/models/ModelsPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useExtensionsStore } from '@shared/stores/extensionsStore'
 import type { AnyExtension, ModelExtension } from '@shared/types/electron.d'
-import { formatModelName } from './utils'
+import { EXTENSION_REPOSITORY_REQUIREMENTS, extensionRemovalCopy, formatModelName } from './utils'
 import { ExtensionCard } from './components/ExtensionCard'
 import type { ExtensionNode } from './components/ExtensionCard'
 import { ExtensionDrawer } from './components/ExtensionDrawer'
@@ -221,6 +221,7 @@ export default function ModelsPage(): JSX.Element {
     const result = await installFromLocal()
     if ('cancelled' in result && result.cancelled) return   // user dismissed dialog
     if (!result.success) setGhErr(result.error ?? 'Installation failed')
+    else if (result.extensionId) setSelectedId(result.extensionId)
   }
 
   // ── Uninstall extension ──────────────────────────────────────────
@@ -354,7 +355,7 @@ export default function ModelsPage(): JSX.Element {
           <button
             onClick={handleLocalInstall}
             disabled={isInstalling}
-            title="Link a local extension folder"
+            title="Link source folder only; setup.py and npm install are not run"
             className="inline-flex items-center gap-2 px-3.5 py-2 rounded-[9px] text-xs font-medium border border-zinc-700/60 bg-white/[0.025] text-zinc-200 hover:bg-white/[0.06] hover:border-zinc-600 transition-colors whitespace-nowrap disabled:opacity-40 disabled:cursor-not-allowed"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" className="opacity-85">
@@ -364,6 +365,15 @@ export default function ModelsPage(): JSX.Element {
           </button>
         </div>
       </div>
+
+      {!showGHForm && ghErr && (
+        <div className="mx-7 mb-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-red-950/30 border border-red-800/30">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-red-400 shrink-0">
+            <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+          </svg>
+          <p className="text-[11px] text-red-400">{ghErr}</p>
+        </div>
+      )}
 
       {/* ── Toolbar ──────────────────────────────────────────────────────── */}
       <div className="flex items-center gap-3 px-7 pb-4 flex-wrap shrink-0">
@@ -537,7 +547,7 @@ export default function ModelsPage(): JSX.Element {
             )}
 
             <p className="text-[10px] text-zinc-600">
-              The repo must contain a <span className="font-mono text-zinc-500">manifest.json</span> and a <span className="font-mono text-zinc-500">generator.py</span> at its root.
+              {EXTENSION_REPOSITORY_REQUIREMENTS}
             </p>
           </div>
         </div>
@@ -638,6 +648,9 @@ export default function ModelsPage(): JSX.Element {
         const installedModels = ext?.type === 'model'
           ? ext.nodes.filter((n) => installedVariantIds.includes(`${uninstallTarget}/${n.id}`))
           : []
+        const removalCopy = ext
+          ? extensionRemovalCopy(ext, modelsToDelete.size)
+          : { title: `Uninstall “${uninstallTarget}”?`, body: 'The extension folder will be permanently deleted.', action: 'Uninstall' }
 
         return createPortal(
           <div
@@ -658,10 +671,10 @@ export default function ModelsPage(): JSX.Element {
                   </div>
                   <div className="flex flex-col gap-1 pt-0.5">
                     <h2 className="text-base font-semibold text-zinc-100 leading-tight">
-                      Uninstall &ldquo;{ext?.name ?? uninstallTarget}&rdquo;?
+                      {removalCopy.title}
                     </h2>
                     <p className="text-xs text-zinc-500 leading-relaxed">
-                      The extension folder will be permanently deleted.
+                      {removalCopy.body}
                     </p>
                   </div>
                 </div>
@@ -719,7 +732,7 @@ export default function ModelsPage(): JSX.Element {
                     onClick={() => handleUninstallExtension(uninstallTarget)}
                     className="flex-1 py-2.5 rounded-xl bg-accent hover:bg-accent-dark text-white text-sm font-semibold transition-colors shadow-lg shadow-accent/20"
                   >
-                    Uninstall
+                    {removalCopy.action}
                   </button>
                 </div>
               </div>

--- a/src/areas/models/components/ExtensionDrawer.tsx
+++ b/src/areas/models/components/ExtensionDrawer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import type { AnyExtension, ExtensionNode } from '@shared/types/electron.d'
 import { useNavStore } from '@shared/stores/navStore'
+import { getLocalSourcePath, localExtensionSetupMessage, supportsExtensionRepair } from '../utils'
 import {
   DownloadMap,
   ICONS,
@@ -41,6 +42,7 @@ export function ExtensionDrawer({
   const [syncError,   setSyncError]   = useState<string | null>(null)
 
   const isModel     = ext.type === 'model'
+  const repairable  = supportsExtensionRepair(ext)
   // Built-ins are corrupted-flagged too (builtin-sync repairs them on restart),
   // but they can't be deleted — show the banner without the delete action.
   const isCorrupted = !!ext.corrupted
@@ -50,8 +52,9 @@ export function ExtensionDrawer({
       : ext.manifestError === 'incomplete'
         ? 'A previous install of this extension never completed. Delete the folder, then install the extension again.'
         : 'This extension folder is incomplete (its manifest is missing) — usually the leftover of an interrupted install. Delete the folder, then install the extension again.'
-  const isLocal = typeof ext.source === 'string' && ext.source.startsWith('local://')
-  const localPath = isLocal ? ext.source!.replace('local://', '') : null
+  const localPath = getLocalSourcePath(ext)
+  const isLocal = localPath !== null
+  const localSetupMessage = localExtensionSetupMessage(ext)
   const { total, done, installing, hasAvailable } = extInstallSummary(ext, installedIds, downloading)
 
   useEffect(() => {
@@ -157,6 +160,12 @@ export function ExtensionDrawer({
                 <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
               </svg>
               <p className="text-[11px] text-red-400 break-all">{error}</p>
+            </div>
+          )}
+
+          {localSetupMessage && (
+            <div className="mb-5 px-3 py-2.5 rounded-lg bg-orange-950/20 border border-orange-800/30">
+              <p className="text-[11px] leading-5 text-orange-300/80">{localSetupMessage}</p>
             </div>
           )}
 
@@ -301,11 +310,11 @@ export function ExtensionDrawer({
             </button>
           )}
 
-          {isModel && !isCorrupted && (
+          {repairable && !isCorrupted && (
             <button
               onClick={handleRepair}
               disabled={repairing || disabled}
-              title="Repair — re-run the extension environment setup"
+              title="Repair — run setup.py for the extension environment"
               className="inline-flex items-center gap-1.5 px-3.5 py-2.5 rounded-[9px] text-xs font-medium border border-zinc-700/60 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {repairing ? (

--- a/src/areas/models/utils.test.mjs
+++ b/src/areas/models/utils.test.mjs
@@ -20,7 +20,14 @@ function loadModule() {
   return require(outfile)
 }
 
-const { formatModelName } = loadModule()
+const {
+  EXTENSION_REPOSITORY_REQUIREMENTS,
+  extensionRemovalCopy,
+  formatModelName,
+  getLocalSourcePath,
+  localExtensionSetupMessage,
+  supportsExtensionRepair,
+} = loadModule()
 
 test('formatModelName turns a hyphenated id into a Title-cased label', () => {
   assert.equal(formatModelName('trellis'), 'Trellis')
@@ -33,4 +40,73 @@ test('formatModelName only capitalizes word-initial chars (digits left as-is)', 
   // a digit is mid-word and stays lower-case.
   assert.equal(formatModelName('a-b-c'), 'A B C')
   assert.equal(formatModelName(''), '')
+})
+
+const baseExtension = {
+  id: 'example',
+  name: 'Example',
+  trusted: false,
+  builtin: false,
+  nodes: [],
+}
+
+test('Repair policy accepts supported Python setup and rejects JS, built-in, and corrupted processes', () => {
+  assert.equal(supportsExtensionRepair({ ...baseExtension, type: 'model' }), true)
+  assert.equal(supportsExtensionRepair({ ...baseExtension, type: 'process', entry: 'processor.py', repairable: true }), true)
+  assert.equal(supportsExtensionRepair({ ...baseExtension, type: 'process', entry: 'processor.py', repairable: false }), false)
+  assert.equal(supportsExtensionRepair({ ...baseExtension, type: 'process', entry: 'processor.js', repairable: true }), false)
+  assert.equal(supportsExtensionRepair({ ...baseExtension, type: 'process', entry: 'processor.py', repairable: true, builtin: true }), false)
+  assert.equal(supportsExtensionRepair({ ...baseExtension, type: 'process', entry: 'processor.py', repairable: true, corrupted: true }), false)
+})
+
+test('local-link guidance directs supported Python processes to Repair without claiming setup ran', () => {
+  const python = {
+    ...baseExtension,
+    type: 'process',
+    entry: 'processor.py',
+    repairable: true,
+    source: 'local:///home/jane doe/process',
+  }
+  const js = {
+    ...baseExtension,
+    type: 'process',
+    entry: 'processor.js',
+    repairable: false,
+    source: 'local://C:\\Users\\Jane Doe\\process',
+  }
+
+  assert.match(localExtensionSetupMessage(python), /linked.*without running setup/i)
+  assert.match(localExtensionSetupMessage(python), /Repair/)
+  assert.match(localExtensionSetupMessage(js), /dependencies and assets were not installed/i)
+  assert.doesNotMatch(localExtensionSetupMessage(js), /Repair/)
+  assert.equal(localExtensionSetupMessage({ ...python, source: 'https://github.com/example/process' }), null)
+})
+
+test('local paths and unlink confirmation remain truthful on Windows and Linux', () => {
+  const windows = { ...baseExtension, type: 'process', entry: 'processor.py', source: 'local://C:\\Users\\Jane Doe\\process' }
+  const linux = { ...baseExtension, type: 'process', entry: 'processor.py', source: 'local:///home/jane doe/process' }
+
+  assert.equal(getLocalSourcePath(windows), 'C:\\Users\\Jane Doe\\process')
+  assert.equal(getLocalSourcePath(linux), '/home/jane doe/process')
+  assert.deepEqual(extensionRemovalCopy(windows), {
+    title: 'Unlink “Example”?',
+    body: 'Modly will remove its link. The source folder and files will remain on disk.',
+    action: 'Unlink',
+  })
+  assert.deepEqual(extensionRemovalCopy({ ...linux, type: 'model' }, 2), {
+    title: 'Unlink “Example”?',
+    body: 'Modly will remove its link and 2 selected model weights. The source folder and files will remain on disk.',
+    action: 'Unlink',
+  })
+  assert.deepEqual(extensionRemovalCopy({ ...baseExtension, type: 'model' }), {
+    title: 'Uninstall “Example”?',
+    body: 'The extension folder will be permanently deleted.',
+    action: 'Uninstall',
+  })
+})
+
+test('repository requirements describe both model and process extension roots', () => {
+  assert.match(EXTENSION_REPOSITORY_REQUIREMENTS, /manifest\.json/)
+  assert.match(EXTENSION_REPOSITORY_REQUIREMENTS, /generator\.py.*model/i)
+  assert.match(EXTENSION_REPOSITORY_REQUIREMENTS, /declared entry.*process/i)
 })

--- a/src/areas/models/utils.ts
+++ b/src/areas/models/utils.ts
@@ -1,5 +1,50 @@
+import type { AnyExtension } from '@shared/types/electron.d'
+
+export const EXTENSION_REPOSITORY_REQUIREMENTS =
+  'The repo must contain a manifest.json plus generator.py for a model extension or the declared entry file for a process extension.'
+
 export function formatModelName(id: string): string {
   return id
     .replace(/-/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+export function getLocalSourcePath(ext: AnyExtension): string | null {
+  return ext.source?.startsWith('local://') ? ext.source.slice('local://'.length) : null
+}
+
+export function supportsExtensionRepair(ext: AnyExtension): boolean {
+  if (ext.corrupted) return false
+  if (ext.type === 'model') return ext.repairable !== false
+  if (ext.builtin) return false
+  return ext.entry.endsWith('.py') && ext.repairable === true
+}
+
+export function localExtensionSetupMessage(ext: AnyExtension): string | null {
+  if (!getLocalSourcePath(ext)) return null
+  if (ext.type === 'process' && supportsExtensionRepair(ext)) {
+    return 'Modly linked this source folder without running setup. Select Repair to install or refresh its Python environment and extension-managed assets.'
+  }
+  return 'Modly linked this source folder only. Dependencies and assets were not installed automatically.'
+}
+
+export function extensionRemovalCopy(
+  ext: AnyExtension,
+  selectedModelWeights = 0,
+): { title: string; body: string; action: string } {
+  if (getLocalSourcePath(ext)) {
+    const selectedWeightsCopy = selectedModelWeights > 0
+      ? ` and ${selectedModelWeights} selected model weight${selectedModelWeights === 1 ? '' : 's'}`
+      : ''
+    return {
+      title: `Unlink “${ext.name}”?`,
+      body: `Modly will remove its link${selectedWeightsCopy}. The source folder and files will remain on disk.`,
+      action: 'Unlink',
+    }
+  }
+  return {
+    title: `Uninstall “${ext.name}”?`,
+    body: 'The extension folder will be permanently deleted.',
+    action: 'Uninstall',
+  }
 }

--- a/src/shared/stores/extensionsStore.ts
+++ b/src/shared/stores/extensionsStore.ts
@@ -27,7 +27,7 @@ interface ExtensionsStore {
 
   loadExtensions:    () => Promise<void>
   installFromGitHub: (url: string) => Promise<{ success: boolean; error?: string }>
-  installFromLocal:  () => Promise<{ success: boolean; error?: string; cancelled?: boolean }>
+  installFromLocal:  () => Promise<{ success: boolean; error?: string; cancelled?: boolean; extensionId?: string }>
   uninstall:         (extensionId: string) => Promise<{ success: boolean; error?: string }>
   reload:            () => Promise<void>
   clearInstallState: () => void

--- a/src/shared/types/electron.d.ts
+++ b/src/shared/types/electron.d.ts
@@ -37,6 +37,8 @@ export interface ModelExtension {
   builtin:      boolean
   source?:      string
   localPath?:   string
+  /** Host-confirmed setup.py route supported by the Repair action. */
+  repairable?:  boolean
   nodes:        ExtensionNode[]
   /** Folder exists but is not a loadable extension — see manifestError */
   corrupted?:   boolean
@@ -71,6 +73,8 @@ export interface ProcessExtension {
   builtin:      boolean
   source?:      string
   localPath?:   string
+  /** Host-confirmed setup.py route supported by the Repair action. */
+  repairable?:  boolean
   entry:        string
   nodes:        ExtensionNode[]
   /** Folder exists but is not a loadable extension — see manifestError */


### PR DESCRIPTION
Closes #263

## Summary

- Pass Modly's configured Models directory to Python PROCESS setup and runtime.
- Validate native absolute storage paths and refresh cached runner state after Repair or configuration changes.
- Preserve existing model-extension, JavaScript PROCESS, workspace, and temporary-directory behavior.

## Changes

| Area | Change |
|------|--------|
| `electron/main/process-extension-contract.ts` | Adds native path validation and typed setup/runtime payload builders. |
| `electron/main/ipc-handlers.ts` | Supplies `models_dir` only to Python PROCESS setup/install/Repair and passes `modelsDir` when running Python processes. |
| `electron/main/process-runner.ts` | Adds `modelsDir` to the runtime payload and refreshes cached Python runner configuration. |
| `src/areas/models/**` | Recognizes Python PROCESS setup capability and exposes the existing Repair flow consistently. |
| `src/shared/**` | Updates extension state and Electron API typings for the additive contract. |
| Contract and utility tests | Covers POSIX, Windows drive-qualified and UNC paths, payload isolation, setup eligibility, and cached-runner refresh behavior. |
| `README.md` | Documents field names, lifecycle responsibilities, compatibility, and privacy boundaries. |

## Compatibility and security

- The new fields are additive.
- Model-extension setup does not receive `models_dir`.
- JavaScript PROCESS context is unchanged.
- `workspaceDir` and `tempDir` retain their existing meaning.
- Raw settings, profiles, credentials, tokens, and environment-derived details are not forwarded.
- Process-owned assets are not deleted automatically when an extension is uninstalled.

## Validation

- [x] Focused contract tests: 16/16 passed.
- [x] Full local test suite: 114/114 passed.
- [x] Targeted TypeScript validation passed.
- [x] Direct `electron-vite` build passed.
- [x] Real Modly Python-process runner integration exercised the explicit `modelsDir` path and produced a valid offline audio artifact.
- [x] Rebased cleanly onto current `main`; diff, privacy, whitespace, and trailer checks passed.
- [ ] Hosted repository CI — pending this PR.
- [ ] Packaged-app Install-from-GitHub and Repair UI regression pass.

## Baseline notes

- Upstream's current lockfile is not synchronized with `package.json`, so the same `npm install` path used by the official CI was used for validation.
- The full baseline TypeScript configurations contain pre-existing diagnostics; normalized diagnostics matched `upstream/main`, while the changed contract and runner paths passed targeted checks.
