### PR TITLE
fix(extensions): force UTF-8 stdio on Windows to stop UnicodeEncodeError crashes

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi import HTTPException
 
+from services.stdio_utf8 import ensure_utf8_stdio
+ensure_utf8_stdio()  # must run before any print/logging hits the pipe
+
 from routers import generation, model, optimize, status, settings, extensions, export, workflow_runs, agent
 
 

--- a/api/runner.py
+++ b/api/runner.py
@@ -44,6 +44,12 @@ if MODLY_API_DIR and MODLY_API_DIR not in sys.path:
 if str(EXT_DIR) not in sys.path:
     sys.path.insert(0, str(EXT_DIR))
 
+# Match the UTF-8 pipe readers on the parent side even when the OS locale
+# is a legacy codepage (cp1252/cp932 on Windows). Without this, any Unicode
+# print() from a generator (e.g. tqdm output) crashes the worker.
+from services.stdio_utf8 import ensure_utf8_stdio
+ensure_utf8_stdio()
+
 
 # ------------------------------------------------------------------ #
 # Protocol helpers

--- a/api/services/extension_process.py
+++ b/api/services/extension_process.py
@@ -73,6 +73,9 @@ class ExtensionProcess:
         env["MODELS_DIR"]    = str(MODELS_DIR)
         env["WORKSPACE_DIR"] = str(WORKSPACE_DIR)
         env["MODLY_API_DIR"] = str(Path(__file__).parent.parent)
+        # Force the worker's Python stdio to UTF-8 so it matches the UTF-8
+        # pipe readers below regardless of the OS locale (cp1252/cp932).
+        env["PYTHONUTF8"] = "1"
         if sys.platform == "darwin":
             env.setdefault("NUMBA_DISABLE_JIT", "1")
         # Pass the exact model_dir so runner.py doesn't have to re-derive it
@@ -110,6 +113,8 @@ class ExtensionProcess:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 bufsize=1,
                 env=self._build_env(),
             )

--- a/api/services/generator_registry.py
+++ b/api/services/generator_registry.py
@@ -654,7 +654,7 @@ class GeneratorRegistry:
         registration_authorization = _consume_registration_validation_capability(
             validation_capability,
         )
-        print("[Registry] Reloading extensions…")
+        print("[Registry] Reloading extensions...")
         for gen in self._generators.values():
             if isinstance(gen, ExtensionProcess):
                 gen.stop()

--- a/api/services/generators/base.py
+++ b/api/services/generators/base.py
@@ -155,7 +155,7 @@ class BaseGenerator(ABC):
 
         from huggingface_hub import snapshot_download
 
-        print(f"[{self.__class__.__name__}] Downloading {self.hf_repo} → {self.model_dir} …")
+        print(f"[{self.__class__.__name__}] Downloading {self.hf_repo} -> {self.model_dir} ...")
         self.model_dir.mkdir(parents=True, exist_ok=True)
 
         ignore = list(self.hf_skip_prefixes) + [

--- a/api/services/stdio_utf8.py
+++ b/api/services/stdio_utf8.py
@@ -1,0 +1,23 @@
+"""
+Force UTF-8 stdio regardless of the OS locale.
+
+Windows embedded Python defaults stdout/stderr/stdin to the active console
+codepage (cp1252, cp932, ...). Any print() containing non-ASCII characters
+(e.g. "→", "…") then crashes with UnicodeEncodeError, and reading UTF-8
+output under a legacy codepage can kill pipe reader threads. Reconfiguring
+all three streams to UTF-8 makes Modly and extension workers agree with the
+UTF-8 pipe readers used on the Electron side.
+"""
+import sys
+
+
+def ensure_utf8_stdio() -> None:
+    """Reconfigure stdin/stdout/stderr to UTF-8 when the streams support it."""
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass

--- a/api/tests/test_base_generator.py
+++ b/api/tests/test_base_generator.py
@@ -1,0 +1,48 @@
+import io
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from services.generators.base import BaseGenerator
+
+
+class _DownloadGen(BaseGenerator):
+    MODEL_ID = "download-test"
+
+    def load(self) -> None:
+        pass
+
+    def generate(self, image_bytes, params, progress_cb=None, cancel_event=None) -> Path:
+        raise NotImplementedError
+
+
+class AutoDownloadPrintTests(unittest.TestCase):
+    def test_download_progress_print_is_ascii_safe(self) -> None:
+        """Regression: Unicode in the print crashes on cp1252/cp932 Windows."""
+        fake_hub = types.ModuleType("huggingface_hub")
+        fake_hub.snapshot_download = lambda **kwargs: None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            gen = _DownloadGen(Path(tmp) / "model", Path(tmp) / "out")
+            gen.hf_repo = "org/repo"
+
+            out = io.StringIO()
+            with (
+                patch.dict(sys.modules, {"huggingface_hub": fake_hub}),
+                redirect_stdout(out),
+            ):
+                gen._auto_download()
+
+        printed = out.getvalue()
+        first_line = printed.splitlines()[0]
+        self.assertTrue(first_line.startswith("[_DownloadGen] Downloading org/repo ->"))
+        self.assertTrue(first_line.endswith("..."))
+        self.assertTrue(all(ord(ch) < 128 for ch in printed))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_extension_process.py
+++ b/api/tests/test_extension_process.py
@@ -90,6 +90,19 @@ class VenvPythonTests(unittest.TestCase):
             self.assertEqual(result, Path("/tmp/ext") / "venv" / "bin" / "python")
 
 
+class BuildEnvTests(unittest.TestCase):
+    def test_forces_utf8_stdio_on_worker(self) -> None:
+        proc = _make_proc()
+        env = proc._build_env()
+        self.assertEqual(env.get("PYTHONUTF8"), "1")
+
+    def test_sets_worker_model_dir_when_known(self) -> None:
+        proc = _make_proc()
+        proc.model_dir = Path("/tmp/models/ext/node")
+        env = proc._build_env()
+        self.assertEqual(env.get("MODEL_DIR"), str(Path("/tmp/models/ext/node")))
+
+
 class MissingModuleExtractionTests(unittest.TestCase):
     def test_extracts_module_name_from_message(self) -> None:
         proc = _make_proc()

--- a/api/tests/test_stdio_utf8.py
+++ b/api/tests/test_stdio_utf8.py
@@ -1,0 +1,58 @@
+import io
+import sys
+import unittest
+from unittest.mock import patch
+
+from services.stdio_utf8 import ensure_utf8_stdio
+
+
+class _RecordingStream:
+    def __init__(self) -> None:
+        self.reconfigure_calls: list[dict] = []
+
+    def reconfigure(self, **kwargs) -> None:
+        self.reconfigure_calls.append(kwargs)
+
+
+class StdioUtf8Tests(unittest.TestCase):
+    def test_reconfigures_all_streams_to_utf8(self) -> None:
+        fake = _RecordingStream()
+        with (
+            patch.object(sys, "stdin", fake),
+            patch.object(sys, "stdout", fake),
+            patch.object(sys, "stderr", fake),
+        ):
+            ensure_utf8_stdio()
+
+        self.assertEqual(
+            fake.reconfigure_calls,
+            [
+                {"encoding": "utf-8", "errors": "replace"},
+                {"encoding": "utf-8", "errors": "replace"},
+                {"encoding": "utf-8", "errors": "replace"},
+            ],
+        )
+
+    def test_skips_streams_without_reconfigure_without_raising(self) -> None:
+        with (
+            patch.object(sys, "stdin", io.StringIO()),
+            patch.object(sys, "stdout", io.StringIO()),
+            patch.object(sys, "stderr", io.StringIO()),
+        ):
+            ensure_utf8_stdio()  # must not raise
+
+    def test_ignores_reconfigure_errors(self) -> None:
+        class _FailingStream:
+            def reconfigure(self, **kwargs):
+                raise ValueError("closed stream")
+
+        with (
+            patch.object(sys, "stdin", _FailingStream()),
+            patch.object(sys, "stdout", _FailingStream()),
+            patch.object(sys, "stderr", _FailingStream()),
+        ):
+            ensure_utf8_stdio()  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/electron/main/process-runner.ts
+++ b/electron/main/process-runner.ts
@@ -180,6 +180,9 @@ export class PythonProcessRunner implements IProcessRunner {
     return new Promise((resolve, reject) => {
       const proc = spawn(this.pythonExe, [this.scriptPath], {
         stdio: ['pipe', 'pipe', 'pipe'],
+        // Force UTF-8 stdio so Unicode prints from process extensions do not
+        // crash under legacy Windows codepages (cp1252/cp932).
+        env: { ...process.env, PYTHONUTF8: '1' },
       })
 
       // Send input as a single JSON line on stdin


### PR DESCRIPTION
Fixes #270 (UnicodeEncodeError during model auto-download) and the deadlock root cause described in #214.

## Problem

On Windows, the embedded Python defaults `stdout`/`stderr`/`stdin` to the active console codepage (`cp1252`, `cp932`, ...). Two failure modes follow:

1. **Crash (reported in #270):** `BaseGenerator._auto_download()` prints `→` and `…`; on `cp1252` stdout this raises `UnicodeEncodeError: 'charmap' codec can't encode character '\u2192'`, aborting the model download for any extension using `_auto_download()` (e.g. triposplat).
2. **Deadlock (reported in #214):** the extension worker emits UTF-8 (and mixed-encoding tqdm output). The parent's `Popen(text=True)` pipe readers decode with the OS locale, so the stderr reader thread dies with `UnicodeDecodeError` on Japanese Windows; the stderr pipe fills and generation hangs forever at 0% CPU.

## Changes

- **`api/services/generators/base.py`** — ASCII-ify the download progress print (`->` / `...`), the exact line from the #270 traceback.
- **`api/services/generator_registry.py`** — ASCII-ify the reload print (`…` -> `...`), same crash class in the API process.
- **`api/services/stdio_utf8.py` (new)** — `ensure_utf8_stdio()` reconfigures stdin/stdout/stderr to UTF-8 with `errors="replace"`, no-op when unsupported.
- **`api/main.py` / `api/runner.py`** — call `ensure_utf8_stdio()` at startup so both the FastAPI process and every extension worker emit UTF-8 regardless of locale.
- **`api/services/extension_process.py`** — spawn workers with `PYTHONUTF8=1` and `Popen(..., encoding="utf-8", errors="replace")` so parent-side pipe readers never die on non-UTF-8 locales (the verified fix from #214).
- **`electron/main/process-runner.ts`** — set `PYTHONUTF8=1` for process-extension spawns (same crash class).

## Tests

- New `api/tests/test_stdio_utf8.py` (3 tests): helper reconfigures all three streams, skips streams without `reconfigure`, swallows errors.
- New `api/tests/test_base_generator.py`: regression test asserting the `_auto_download` print is ASCII-safe.
- `api/tests/test_extension_process.py`: asserts `_build_env()` sets `PYTHONUTF8=1`.

All 6 new tests pass. Node suite: 95/95 pass. Pre-existing failures on `origin/dev` (2 registry tests + `fastapi` import in system Python) are unchanged by this PR.