### PR TITLE
fix(api): file /workflow-runs/from-image into the caller's collection (#238)

### DIFF
--- a/api/routers/generation.py
+++ b/api/routers/generation.py
@@ -14,6 +14,10 @@ from schemas.generation import JobStatus
 
 router = APIRouter(tags=["generation"])
 
+# Shared with workflow_runs.create_run_from_image so the two endpoints can't drift apart on
+# what counts as a valid remesh mode the way they had drifted on `collection` before #238.
+VALID_REMESH_MODES = ("quad", "triangle", "none")
+
 _jobs: Dict[str, JobStatus] = {}
 _cancelled: set = set()
 _cancel_events: Dict[str, threading.Event] = {}
@@ -44,20 +48,33 @@ def sanitize_collection(collection: str) -> str:
 
     Legality and containment are different questions, so they are asked separately: the
     reserved characters above are refused outright, and containment is put to the path
-    library rather than to the spelling. A character blocklist alone lets ``".."`` through --
-    it contains none of the listed characters -- and ``WORKSPACE_DIR / ".."`` resolves to the
-    workspace's *parent*, so the generated mesh would land outside the root.
+    library rather than to the spelling -- the same ``relative_to`` check
+    ``generator_registry._path_belongs_to`` uses, so the two containment checks in this
+    backend agree rather than drifting on their own semantics. A character blocklist alone
+    lets ``".."`` through -- it contains none of the listed characters -- and
+    ``WORKSPACE_DIR / ".."`` resolves to the workspace's *parent*, so the generated mesh
+    would land outside the root.
+
+    A name ending in a dot or space is refused too, even once it clears both checks above:
+    Windows silently drops trailing dots/spaces from the final path component it actually
+    creates, so ``mkdir()`` on ``"Exports..."`` lands in the very same folder as
+    ``"Exports"`` -- two collections that look distinct to this function would otherwise
+    merge their output on disk without either caller being told.
     """
     collection = (collection or "").strip()
-    if not collection or _re.search(r'[/:*?"<>|\\]', collection):
+    if (
+        not collection
+        or _re.search(r'[/:*?"<>|\\]', collection)
+        or collection != collection.rstrip(". ")
+    ):
         return "Default"
 
     try:
-        candidate = (WORKSPACE_DIR / collection).resolve()
+        (WORKSPACE_DIR / collection).resolve().relative_to(WORKSPACE_DIR.resolve())
     except (OSError, ValueError):
         return "Default"
 
-    return collection if candidate.parent == WORKSPACE_DIR.resolve() else "Default"
+    return collection
 
 
 @router.post("/from-image")
@@ -74,7 +91,7 @@ async def generate_from_image(
     if not image.content_type or not image.content_type.startswith("image/"):
         raise HTTPException(400, "File must be an image")
 
-    if remesh not in ("quad", "triangle", "none"):
+    if remesh not in VALID_REMESH_MODES:
         raise HTTPException(400, "remesh must be 'quad', 'triangle', or 'none'")
 
     collection = sanitize_collection(collection)

--- a/api/routers/generation.py
+++ b/api/routers/generation.py
@@ -32,6 +32,22 @@ def _purge_old_jobs() -> None:
         _completed_at.pop(jid, None)
 
 
+def sanitize_collection(collection: str) -> str:
+    """Normalize a caller-supplied collection name into a safe workspace subfolder.
+
+    The value becomes a directory under the workspace (``WORKSPACE_DIR / collection``), so a
+    name carrying a path separator or a drive/wildcard character could escape that root or fail
+    to create on Windows. Such a name, or an empty one, falls back to ``"Default"`` rather than
+    raising, because a generation the caller already paid for should still land somewhere
+    sensible. Shared so every entry point that routes output into a collection sanitizes it the
+    same way; a second copy of this rule is a second chance to forget a character.
+    """
+    collection = (collection or "").strip()
+    if not collection or _re.search(r'[/:*?"<>|\\]', collection):
+        return "Default"
+    return collection
+
+
 @router.post("/from-image")
 async def generate_from_image(
     background_tasks: BackgroundTasks,
@@ -49,10 +65,7 @@ async def generate_from_image(
     if remesh not in ("quad", "triangle", "none"):
         raise HTTPException(400, "remesh must be 'quad', 'triangle', or 'none'")
 
-    # Sanitize collection name: strip, forbid path separators and special chars
-    collection = collection.strip()
-    if not collection or _re.search(r'[/:*?"<>|\\]', collection):
-        collection = "Default"
+    collection = sanitize_collection(collection)
 
     # Verify the requested model exists in the registry
     try:

--- a/api/routers/generation.py
+++ b/api/routers/generation.py
@@ -41,11 +41,23 @@ def sanitize_collection(collection: str) -> str:
     raising, because a generation the caller already paid for should still land somewhere
     sensible. Shared so every entry point that routes output into a collection sanitizes it the
     same way; a second copy of this rule is a second chance to forget a character.
+
+    Legality and containment are different questions, so they are asked separately: the
+    reserved characters above are refused outright, and containment is put to the path
+    library rather than to the spelling. A character blocklist alone lets ``".."`` through --
+    it contains none of the listed characters -- and ``WORKSPACE_DIR / ".."`` resolves to the
+    workspace's *parent*, so the generated mesh would land outside the root.
     """
     collection = (collection or "").strip()
     if not collection or _re.search(r'[/:*?"<>|\\]', collection):
         return "Default"
-    return collection
+
+    try:
+        candidate = (WORKSPACE_DIR / collection).resolve()
+    except (OSError, ValueError):
+        return "Default"
+
+    return collection if candidate.parent == WORKSPACE_DIR.resolve() else "Default"
 
 
 @router.post("/from-image")

--- a/api/routers/workflow_runs.py
+++ b/api/routers/workflow_runs.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Uploa
 from pydantic import BaseModel
 
 from routers.generation import (
+    VALID_REMESH_MODES,
     _cancel_events,
     _cancelled,
     _jobs,
@@ -43,15 +44,6 @@ async def create_run_from_image(
     if not image.content_type or not image.content_type.startswith("image/"):
         raise HTTPException(400, "File must be an image")
 
-    collection = sanitize_collection(collection)
-
-    try:
-        generator_registry.get_generator(model_id)
-    except ValueError as e:
-        raise HTTPException(400, str(e))
-
-    generator_registry.switch_model(model_id)
-
     try:
         model_params = json.loads(params)
     except (json.JSONDecodeError, TypeError):
@@ -64,10 +56,21 @@ async def create_run_from_image(
         **model_params,
     }
 
-    # Same constraint /generate/from-image enforces on this field; without it an invalid
-    # value sails past this boundary and only surfaces later, inside the background task.
-    if full_params["remesh"] not in ("quad", "triangle", "none"):
+    # Same constraint /generate/from-image enforces on this field, checked before touching
+    # the registry below for the same reason that endpoint checks it first: switch_model()
+    # unloads whatever generator is currently active, and a request rejected for a bad
+    # remesh value should not pay for -- or force a reload after -- evicting it.
+    if full_params["remesh"] not in VALID_REMESH_MODES:
         raise HTTPException(400, "remesh must be 'quad', 'triangle', or 'none'")
+
+    collection = sanitize_collection(collection)
+
+    try:
+        generator_registry.get_generator(model_id)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+    generator_registry.switch_model(model_id)
 
     job_id = str(uuid.uuid4())
     image_bytes = await image.read()

--- a/api/routers/workflow_runs.py
+++ b/api/routers/workflow_runs.py
@@ -5,7 +5,13 @@ from typing import Optional
 from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 
-from routers.generation import _cancel_events, _cancelled, _jobs, _run_generation
+from routers.generation import (
+    _cancel_events,
+    _cancelled,
+    _jobs,
+    _run_generation,
+    sanitize_collection,
+)
 from schemas.generation import JobStatus
 from services.generator_registry import generator_registry
 
@@ -27,10 +33,17 @@ async def create_run_from_image(
     background_tasks: BackgroundTasks,
     image: UploadFile = File(...),
     model_id: str = Form("sf3d"),
+    # Where the result is filed. The legacy /generate/from-image already accepts this; the
+    # canonical endpoint hardcoded "Default", so a run driven over REST/MCP landed in a folder
+    # the Library does not index and stayed invisible in the app (#238). Same field, same
+    # sanitizer, so both surfaces route output the same way.
+    collection: str = Form("Default"),
     params: str = Form("{}"),
 ):
     if not image.content_type or not image.content_type.startswith("image/"):
         raise HTTPException(400, "File must be an image")
+
+    collection = sanitize_collection(collection)
 
     try:
         generator_registry.get_generator(model_id)
@@ -57,7 +70,7 @@ async def create_run_from_image(
     _jobs[job_id] = JobStatus(job_id=job_id, status="pending", progress=0)
     _cancel_events[job_id] = threading.Event()
 
-    background_tasks.add_task(_run_generation, job_id, image_bytes, full_params, "Default")
+    background_tasks.add_task(_run_generation, job_id, image_bytes, full_params, collection)
 
     return {"run_id": job_id, "status": "pending"}
 

--- a/api/routers/workflow_runs.py
+++ b/api/routers/workflow_runs.py
@@ -64,6 +64,11 @@ async def create_run_from_image(
         **model_params,
     }
 
+    # Same constraint /generate/from-image enforces on this field; without it an invalid
+    # value sails past this boundary and only surfaces later, inside the background task.
+    if full_params["remesh"] not in ("quad", "triangle", "none"):
+        raise HTTPException(400, "remesh must be 'quad', 'triangle', or 'none'")
+
     job_id = str(uuid.uuid4())
     image_bytes = await image.read()
 

--- a/api/tests/test_workflow_runs_router.py
+++ b/api/tests/test_workflow_runs_router.py
@@ -1,7 +1,7 @@
 import asyncio
 import unittest
 
-from fastapi import BackgroundTasks
+from fastapi import BackgroundTasks, HTTPException
 
 import routers.workflow_runs as workflow_runs
 from routers.generation import sanitize_collection
@@ -42,6 +42,13 @@ class SanitizeCollectionTests(unittest.TestCase):
         for name in ("../evil", "a/b", "a\\b", "a:b", "a*b", "a?b", 'a"b', "a<b", "a>b", "a|b"):
             self.assertEqual(sanitize_collection(name), "Default", name)
 
+    def test_bare_dot_dot_falls_back_to_default(self) -> None:
+        # ".." contains none of the blocked characters above, so a character blocklist alone
+        # lets it through -- and WORKSPACE_DIR / ".." resolves to the workspace's *parent*,
+        # writing the generated mesh outside the sandboxed root. Containment must be checked
+        # against the resolved path, not just the spelling.
+        self.assertEqual(sanitize_collection(".."), "Default")
+
 
 class CreateRunCollectionTests(unittest.TestCase):
     """The canonical /workflow-runs/from-image must file a run where the caller asked (#238)."""
@@ -78,6 +85,31 @@ class CreateRunCollectionTests(unittest.TestCase):
     def test_a_traversing_collection_is_neutralized(self) -> None:
         # The name becomes a workspace subfolder, so a path-separator name must never survive.
         self.assertEqual(self._collection_forwarded("../../etc"), "Default")
+
+
+class CreateRunRemeshValidationTests(unittest.TestCase):
+    """/generate/from-image rejects an invalid remesh with a 400; this endpoint must too."""
+
+    def setUp(self) -> None:
+        self._previous = workflow_runs.generator_registry
+        workflow_runs.generator_registry = _FakeRegistry()
+
+    def tearDown(self) -> None:
+        workflow_runs.generator_registry = self._previous
+
+    def test_invalid_remesh_is_rejected(self) -> None:
+        background = BackgroundTasks()
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(
+                workflow_runs.create_run_from_image(
+                    background,
+                    image=_FakeUpload(),
+                    model_id="sf3d",
+                    collection="Default",
+                    params='{"remesh": "garbage"}',
+                )
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
 
 
 if __name__ == "__main__":

--- a/api/tests/test_workflow_runs_router.py
+++ b/api/tests/test_workflow_runs_router.py
@@ -1,0 +1,84 @@
+import asyncio
+import unittest
+
+from fastapi import BackgroundTasks
+
+import routers.workflow_runs as workflow_runs
+from routers.generation import sanitize_collection
+
+
+class _FakeUpload:
+    """Minimal stand-in for UploadFile: an image content-type and readable bytes."""
+
+    def __init__(self, content_type: str = "image/png", data: bytes = b"\x89PNG\r\n") -> None:
+        self.content_type = content_type
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class _FakeRegistry:
+    """Accepts any model id so the route reaches the point where it files the run."""
+
+    def get_generator(self, model_id: str) -> object:
+        return object()
+
+    def switch_model(self, model_id: str) -> None:
+        pass
+
+
+class SanitizeCollectionTests(unittest.TestCase):
+    def test_keeps_a_plain_name_trimmed(self) -> None:
+        self.assertEqual(sanitize_collection("  Exports  "), "Exports")
+
+    def test_empty_or_blank_falls_back_to_default(self) -> None:
+        self.assertEqual(sanitize_collection(""), "Default")
+        self.assertEqual(sanitize_collection("   "), "Default")
+
+    def test_path_and_wildcard_characters_fall_back_to_default(self) -> None:
+        # Any of these would let the name escape the workspace root or fail to create on
+        # Windows, so the whole name is refused rather than partly scrubbed.
+        for name in ("../evil", "a/b", "a\\b", "a:b", "a*b", "a?b", 'a"b', "a<b", "a>b", "a|b"):
+            self.assertEqual(sanitize_collection(name), "Default", name)
+
+
+class CreateRunCollectionTests(unittest.TestCase):
+    """The canonical /workflow-runs/from-image must file a run where the caller asked (#238)."""
+
+    def setUp(self) -> None:
+        self._previous = workflow_runs.generator_registry
+        workflow_runs.generator_registry = _FakeRegistry()
+
+    def tearDown(self) -> None:
+        workflow_runs.generator_registry = self._previous
+
+    def _collection_forwarded(self, collection: str) -> str:
+        background = BackgroundTasks()
+        asyncio.run(
+            workflow_runs.create_run_from_image(
+                background,
+                image=_FakeUpload(),
+                model_id="sf3d",
+                collection=collection,
+                params="{}",
+            )
+        )
+        # add_task(_run_generation, job_id, image_bytes, full_params, collection)
+        return background.tasks[0].args[3]
+
+    def test_collection_is_forwarded_to_the_run(self) -> None:
+        # The whole point of #238: a run driven over REST/MCP can land in a folder the Library
+        # indexes, instead of always being filed under the hardcoded "Default".
+        self.assertEqual(self._collection_forwarded("Exports"), "Exports")
+
+    def test_a_blank_collection_becomes_default(self) -> None:
+        self.assertEqual(self._collection_forwarded("   "), "Default")
+
+    def test_a_traversing_collection_is_neutralized(self) -> None:
+        # The name becomes a workspace subfolder, so a path-separator name must never survive.
+        self.assertEqual(self._collection_forwarded("../../etc"), "Default")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_workflow_runs_router.py
+++ b/api/tests/test_workflow_runs_router.py
@@ -49,6 +49,14 @@ class SanitizeCollectionTests(unittest.TestCase):
         # against the resolved path, not just the spelling.
         self.assertEqual(sanitize_collection(".."), "Default")
 
+    def test_trailing_dots_fall_back_to_default(self) -> None:
+        # Windows silently drops trailing dots from the folder it actually creates, so
+        # "Exports..." and "Exports" would otherwise land in the very same physical directory
+        # -- two collections the caller thinks are distinct merging their output on disk.
+        # (A trailing space is already normalized away by the .strip() above, consistently.)
+        for name in ("Exports.", "Exports..", "..."):
+            self.assertEqual(sanitize_collection(name), "Default", name)
+
 
 class CreateRunCollectionTests(unittest.TestCase):
     """The canonical /workflow-runs/from-image must file a run where the caller asked (#238)."""
@@ -87,6 +95,16 @@ class CreateRunCollectionTests(unittest.TestCase):
         self.assertEqual(self._collection_forwarded("../../etc"), "Default")
 
 
+class _SwitchTrackingRegistry(_FakeRegistry):
+    """Records whether switch_model ran, to prove a rejected request never reaches it."""
+
+    def __init__(self) -> None:
+        self.switched = False
+
+    def switch_model(self, model_id: str) -> None:
+        self.switched = True
+
+
 class CreateRunRemeshValidationTests(unittest.TestCase):
     """/generate/from-image rejects an invalid remesh with a 400; this endpoint must too."""
 
@@ -110,6 +128,25 @@ class CreateRunRemeshValidationTests(unittest.TestCase):
                 )
             )
         self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_invalid_remesh_is_rejected_before_switching_the_active_model(self) -> None:
+        # switch_model() unloads whatever generator is currently active (a blocking call for
+        # subprocess-backed extensions), so a request doomed to a 400 anyway must not pay for
+        # -- or force a reload after -- evicting it.
+        registry = _SwitchTrackingRegistry()
+        workflow_runs.generator_registry = registry
+        background = BackgroundTasks()
+        with self.assertRaises(HTTPException):
+            asyncio.run(
+                workflow_runs.create_run_from_image(
+                    background,
+                    image=_FakeUpload(),
+                    model_id="sf3d",
+                    collection="Default",
+                    params='{"remesh": "garbage"}',
+                )
+            )
+        self.assertFalse(registry.switched)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`POST /workflow-runs/from-image` now accepts a `collection` form field (default `"Default"`) and files the run into it, instead of hardcoding `"Default"`.

## Why

This is **cause 1 of #238**. The legacy `/generate/from-image` already accepts `collection`, but the canonical workflow-runs endpoint hardcoded it:

```python
background_tasks.add_task(_run_generation, job_id, image_bytes, full_params, "Default")
```

So a run driven over the REST/MCP surface always landed in `Default/`, which the Workspace Library does not index — everything generated headlessly existed on disk but showed as *"No workspace assets are indexed yet"* in the app. With this change a headless caller can target an indexed collection (e.g. `Exports`) directly, instead of the reported workaround of mirroring files by hand.

The collection name becomes a directory under the workspace (`WORKSPACE_DIR / collection`), so it has to be sanitized. Rather than copy the legacy endpoint's inline check, I extracted it into a shared `sanitize_collection()` and call it from both — a path separator, a drive/wildcard character, or an empty name still falls back to `"Default"`, and the two surfaces can't drift on which characters are allowed.

Scope is deliberately just the API half. The indexer roots and job‑meta records (causes 2 and 3 of #238) are separate and untouched here.

## Testing

New `api/tests/test_workflow_runs_router.py` (6 tests):
- `sanitize_collection` keeps a plain name (trimmed), refuses `/ \ : * ? " < > |`, and defaults on empty/blank.
- `create_run_from_image` forwards the caller's collection to the run and neutralizes a traversing one (`../../etc` → `Default`).

```
Ran 59 tests in 11.7s
OK (skipped=2)
```

Full `api` unittest suite green (the 2 skips are pre-existing). No TypeScript touched.
