### PR TITLE
fix(agent): surface HTTP errors from the unload_models tool

### DIFF
--- a/api/routers/agent.py
+++ b/api/routers/agent.py
@@ -267,7 +267,8 @@ async def execute_tool(name: str, arguments: dict, context: dict) -> tuple[str, 
                 return f"Available models:\n{lines}", None
 
             elif name == "unload_models":
-                await client.post(f"{MODLY_API}/model/unload-all")
+                r = await client.post(f"{MODLY_API}/model/unload-all")
+                r.raise_for_status()
                 return "All 3D generation models have been unloaded from VRAM.", None
 
             elif name == "get_mesh_info":

--- a/api/tests/test_agent_router.py
+++ b/api/tests/test_agent_router.py
@@ -1,0 +1,53 @@
+import asyncio
+import unittest
+from unittest import mock
+
+import httpx
+
+import routers.agent as agent
+
+
+class _MockClientFactory:
+    """Builds real AsyncClients wired to a MockTransport, so execute_tool talks to
+    a fake Modly API instead of the network."""
+
+    def __init__(self, handler) -> None:
+        self._handler = handler
+        self._real = httpx.AsyncClient
+
+    def __call__(self, *args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(self._handler)
+        return self._real(*args, **kwargs)
+
+
+def _run_tool(name: str, handler) -> tuple[str, object]:
+    factory = _MockClientFactory(handler)
+    with mock.patch.object(agent.httpx, "AsyncClient", factory):
+        return asyncio.run(agent.execute_tool(name, {}, {}))
+
+
+class UnloadModelsErrorTests(unittest.TestCase):
+    """unload_models must report a failed unload, not claim success (like every
+    other POST tool and like the MCP server's modly_unload_models)."""
+
+    def test_http_error_is_surfaced(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="boom")
+
+        text, payload = _run_tool("unload_models", handler)
+        # Before the fix the response was discarded and the success string was
+        # returned even on a 500; now the shared HTTPStatusError handler runs.
+        self.assertTrue(text.startswith("API error 500"), text)
+        self.assertIsNone(payload)
+
+    def test_success_still_reports_unloaded(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ok": True})
+
+        text, payload = _run_tool("unload_models", handler)
+        self.assertIn("unloaded", text.lower())
+        self.assertIsNone(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

The `unload_models` chat tool discarded the response from `POST /model/unload-all` and unconditionally returned the success string, so a *failed* unload (any 4xx/5xx) still told the assistant — and the user — that VRAM had been freed.

## Why it triggers

`execute_tool` (`api/routers/agent.py`) wraps every tool call in a shared `except httpx.HTTPStatusError` handler that turns an HTTP error status into `"API error <status>: ..."`. But httpx does **not** raise on an error status unless you call `raise_for_status()`. Every other POST-based tool — `list_models`, `decimate_mesh`, `smooth_mesh`, `get_generation_status` — captures the response and calls `raise_for_status()`, and the MCP server's `modly_unload_models` does too. `unload_models` was the only one that fired the request and threw the response away, so a 500 from the unload endpoint was reported to the model as a success.

```python
elif name == "unload_models":
    await client.post(f"{MODLY_API}/model/unload-all")   # response ignored
    return "All 3D generation models have been unloaded from VRAM.", None
```

## Fix

Capture the response and call `raise_for_status()`, matching the sibling tools and the MCP server. The existing `HTTPStatusError` handler then surfaces the real failure.

## Verification

- Added `api/tests/test_agent_router.py` (unittest + `httpx.MockTransport`). `test_http_error_is_surfaced` **fails before** this change (it gets the success string back for a mocked 500) and **passes after**; `test_success_still_reports_unloaded` guards the happy path.
- `python -m unittest discover -s tests` in `api/` (venv with `fastapi` + `python-multipart` + `httpx`): all pass, 0 failures.
