### PR TITLE
fix(generate): read WORKSPACE_DIR dynamically so relocated output isn't lost

### DIFF
--- a/api/routers/generation.py
+++ b/api/routers/generation.py
@@ -9,7 +9,11 @@ from fastapi import APIRouter, File, Form, UploadFile, HTTPException, Background
 from services.generators.base import smooth_progress, GenerationCancelled
 
 import re as _re
-from services.generator_registry import generator_registry, WORKSPACE_DIR
+# Import the module (not the name) so WORKSPACE_DIR is read at call time: the
+# settings endpoint rebinds it when the user relocates the workspace, and a
+# binding captured at import would keep writing output to the old directory.
+import services.generator_registry as registry
+from services.generator_registry import generator_registry
 from schemas.generation import JobStatus
 
 router = APIRouter(tags=["generation"])
@@ -70,7 +74,9 @@ def sanitize_collection(collection: str) -> str:
         return "Default"
 
     try:
-        (WORKSPACE_DIR / collection).resolve().relative_to(WORKSPACE_DIR.resolve())
+        (registry.WORKSPACE_DIR / collection).resolve().relative_to(
+            registry.WORKSPACE_DIR.resolve()
+        )
     except (OSError, ValueError):
         return "Default"
 
@@ -206,7 +212,7 @@ async def _run_generation(job_id: str, image_bytes: bytes, params: dict, collect
             return
 
         # Direct output to the collection subfolder
-        coll_dir = WORKSPACE_DIR / collection
+        coll_dir = registry.WORKSPACE_DIR / collection
         coll_dir.mkdir(parents=True, exist_ok=True)
         gen.outputs_dir = coll_dir
 
@@ -227,7 +233,7 @@ async def _run_generation(job_id: str, image_bytes: bytes, params: dict, collect
         job.progress = 100
         _completed_at[job_id] = time.monotonic()
         try:
-            rel = output_path.relative_to(WORKSPACE_DIR)
+            rel = output_path.relative_to(registry.WORKSPACE_DIR)
             job.output_url = f"/workspace/{rel.as_posix()}"
         except ValueError:
             job.output_url = f"/workspace/{collection}/{output_path.name}"

--- a/api/tests/test_generation_router.py
+++ b/api/tests/test_generation_router.py
@@ -1,0 +1,151 @@
+import asyncio
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+from fastapi import BackgroundTasks
+
+import services.generator_registry as registry
+import routers.generation as generation
+from schemas.generation import JobStatus
+
+
+class _FakeGenerator:
+    """Writes its output into whatever directory generation assigns it."""
+
+    def __init__(self) -> None:
+        self.outputs_dir: Path | None = None
+
+    def generate(self, image_bytes, params, progress_cb, cancel_event=None) -> Path:
+        out = Path(self.outputs_dir) / "model.glb"
+        out.write_bytes(b"glb")
+        return out
+
+
+class _FakeUpload:
+    """Minimal UploadFile stand-in: an image content-type and readable bytes."""
+
+    def __init__(self, content_type: str = "image/png", data: bytes = b"\x89PNG\r\n") -> None:
+        self.content_type = content_type
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class _FakeRegistry:
+    def __init__(self, gen: _FakeGenerator) -> None:
+        self._gen = gen
+
+    def active_status(self) -> dict:
+        # Report loaded so _run_generation skips the download/load thread.
+        return {"loaded": True, "name": "fake", "downloaded": True}
+
+    def get_active(self) -> _FakeGenerator:
+        return self._gen
+
+    # generate_from_image looks the model up and switches to it before filing the job.
+    def get_generator(self, model_id: str) -> _FakeGenerator:
+        return self._gen
+
+    def switch_model(self, model_id: str) -> None:
+        pass
+
+
+class RunGenerationWorkspaceTests(unittest.TestCase):
+    """A generation started after the workspace path is relocated at runtime
+    (POST /settings/paths) must file its output under the *current* workspace,
+    not the one captured when the module was imported."""
+
+    def setUp(self) -> None:
+        self._prev_registry = generation.generator_registry
+        self._prev_ws = registry.WORKSPACE_DIR
+        self._tmp = tempfile.TemporaryDirectory()
+        # The user relocated the workspace: the registry global now points here.
+        registry.WORKSPACE_DIR = Path(self._tmp.name) / "new_workspace"
+        # Keep the test hermetic against the module's import-time binding: if the
+        # stale name still exists (before the fix) redirect it into the temp tree
+        # so the assertion — not a stray write to the real workspace — is what
+        # catches the bug.
+        self._had_stale = hasattr(generation, "WORKSPACE_DIR")
+        if self._had_stale:
+            generation.WORKSPACE_DIR = Path(self._tmp.name) / "old_workspace"
+
+    def tearDown(self) -> None:
+        generation.generator_registry = self._prev_registry
+        registry.WORKSPACE_DIR = self._prev_ws
+        if self._had_stale:
+            generation.WORKSPACE_DIR = self._prev_ws
+        for store in (
+            generation._jobs,
+            generation._cancel_events,
+            generation._cancelled,
+            generation._completed_at,
+        ):
+            store.clear()
+        self._tmp.cleanup()
+
+    def _run(self, collection: str) -> tuple[_FakeGenerator, JobStatus]:
+        gen = _FakeGenerator()
+        generation.generator_registry = _FakeRegistry(gen)
+        job_id = "job-test"
+        generation._jobs[job_id] = JobStatus(job_id=job_id, status="pending", progress=0)
+        generation._cancel_events[job_id] = threading.Event()
+        asyncio.run(generation._run_generation(job_id, b"img", {}, collection))
+        return gen, generation._jobs[job_id]
+
+    def test_output_lands_under_the_current_workspace(self) -> None:
+        gen, job = self._run("MyColl")
+        self.assertEqual(Path(gen.outputs_dir), registry.WORKSPACE_DIR / "MyColl")
+        self.assertEqual(job.status, "done")
+        self.assertEqual(job.output_url, "/workspace/MyColl/model.glb")
+
+
+class GenerateFromImageWorkspaceTests(unittest.TestCase):
+    """The request path must survive the relocation too, not just the worker:
+    sanitize_collection() checks the name's containment against the workspace
+    root before the job is filed, so it has to read the same live binding -- a
+    stale (or missing) module-level name there fails every POST
+    /generate/from-image, whatever _run_generation does afterwards."""
+
+    def setUp(self) -> None:
+        self._prev_registry = generation.generator_registry
+        self._prev_ws = registry.WORKSPACE_DIR
+        self._tmp = tempfile.TemporaryDirectory()
+        registry.WORKSPACE_DIR = Path(self._tmp.name) / "new_workspace"
+        generation.generator_registry = _FakeRegistry(_FakeGenerator())
+
+    def tearDown(self) -> None:
+        generation.generator_registry = self._prev_registry
+        registry.WORKSPACE_DIR = self._prev_ws
+        for store in (
+            generation._jobs,
+            generation._cancel_events,
+            generation._cancelled,
+            generation._completed_at,
+        ):
+            store.clear()
+        self._tmp.cleanup()
+
+    def test_request_is_filed_after_the_workspace_moves(self) -> None:
+        background = BackgroundTasks()
+        response = asyncio.run(
+            generation.generate_from_image(
+                background,
+                image=_FakeUpload(),
+                model_id="sf3d",
+                collection="MyColl",
+                remesh="quad",
+                enable_texture=False,
+                texture_resolution=1024,
+                params="{}",
+            )
+        )
+        self.assertIn(response["job_id"], generation._jobs)
+        # add_task(_run_generation, job_id, image_bytes, full_params, collection)
+        self.assertEqual(background.tasks[0].args[3], "MyColl")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

After the workspace is relocated at runtime (`POST /settings/paths`), 3D generations kept writing their output into the **previous** workspace directory, while `/workspace/{path}` served files from the **new** one — so the finished mesh 404s and never appears in the app.

## Why it triggers

`api/routers/generation.py` bound the workspace path with `from services.generator_registry import WORKSPACE_DIR`, capturing the `Path` at import time. `POST /settings/paths` → `generator_registry.update_paths()` **rebinds** the `WORKSPACE_DIR` module global (and repoints every loaded generator's `outputs_dir`):

```python
# services/generator_registry.py
_self_module.WORKSPACE_DIR = workspace_dir
for gen in self._generators.values():
    gen.outputs_dir = workspace_dir
```

Because `_run_generation` used the stale imported name, it recomputed `coll_dir = WORKSPACE_DIR / collection` against the **old** directory and set `gen.outputs_dir` back to it — overriding the value `update_paths` had just written — then built `output_url` relative to the same stale path. `/workspace/...` reads the *current* `WORKSPACE_DIR` dynamically, so it can't find the file.

This affects both `/generate/from-image` and `/workflow-runs/from-image` (both funnel through `_run_generation`).

## Fix

Reference the module attribute `registry.WORKSPACE_DIR` at call time instead of a name captured at import — the same way `optimize.ply_to_splat` (comment: *"workspace dir may change at runtime"*) and the settings router already read it.

## Verification

- Added `api/tests/test_generation_router.py`: drives `_run_generation` with a fake generator after relocating the workspace, and asserts the output is filed under the **current** workspace (and that `output_url` matches). Fails before, passes after.
- `python -m unittest discover -s tests` in `api/` (venv with `fastapi` + `python-multipart` + `httpx`): all pass, 0 failures.
